### PR TITLE
fix: import on Python 3.8 (typing.* forms, runtime abc subscripts)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,9 +118,14 @@ reportMissingTypeStubs = false
 
 [tool.ruff]
 line-length = 88
-target-version = "py310"
+target-version = "py38"
 select = ["E", "F", "I", "N", "W", "UP"]
-ignore = ["E501"]
+# The package supports Python 3.8 and uses pydantic, which evaluates
+# annotations at runtime. pyupgrade's annotation rewrites assume
+# ``from __future__ import annotations`` makes the modern ``list[...]`` /
+# ``X | None`` forms safe, but pydantic resolves the stringified annotations
+# on import and those forms raise on 3.8. Keep the typing.* forms.
+ignore = ["E501", "UP006", "UP007", "UP035", "UP037", "UP045"]
 
 [tool.ruff.per-file-ignores]
 # Tests build classes dynamically and bind them to PascalCase locals.

--- a/registry/__main__.py
+++ b/registry/__main__.py
@@ -29,7 +29,7 @@ import pprint
 import sys
 import traceback
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 
 from ._version import __version__, print_version_info
 from .container import is_build_cfg, normalize_cfg
@@ -43,7 +43,7 @@ def cmd_info(args: argparse.Namespace) -> int:
     return 0
 
 
-def load_config_file(filepath: Path) -> dict[str, Any]:
+def load_config_file(filepath: Path) -> Dict[str, Any]:
     """Load a config file using the appropriate engine.
 
     Args:
@@ -107,7 +107,7 @@ def cmd_build(args: argparse.Namespace) -> int:
         print("Error: No BuildCfg entries found in config", file=sys.stderr)
         return 1
 
-    results: dict[str, Any] = {}
+    results: Dict[str, Any] = {}
     for name, cfg_dict in configs_to_build:
         try:
             cfg = normalize_cfg(cfg_dict)
@@ -141,7 +141,7 @@ def cmd_build(args: argparse.Namespace) -> int:
 
     if args.output:
         output_path = Path(args.output)
-        output_data: dict[str, Any] = {}
+        output_data: Dict[str, Any] = {}
         for name, obj in results.items():
             try:
                 if hasattr(obj, "model_dump"):
@@ -179,7 +179,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     if args.verbose:
         print(f"Loaded config from: {filepath}")
 
-    ctx: dict[str, Any] = {}
+    ctx: Dict[str, Any] = {}
 
     if is_build_cfg(config):
         try:

--- a/registry/_version.py
+++ b/registry/_version.py
@@ -29,7 +29,7 @@ import importlib.util
 import platform
 import subprocess
 import sys
-from typing import Any
+from typing import Any, Dict, Optional
 
 # Version components
 VERSION_MAJOR = 0
@@ -51,7 +51,7 @@ def get_version() -> str:
     return f"{VERSION_MAJOR}.{VERSION_MINOR}.{VERSION_PATCH}"
 
 
-def get_python_info() -> dict[str, str]:
+def get_python_info() -> Dict[str, str]:
     """Get Python interpreter information.
 
     Returns:
@@ -65,7 +65,7 @@ def get_python_info() -> dict[str, str]:
     }
 
 
-def get_platform_info() -> dict[str, str]:
+def get_platform_info() -> Dict[str, str]:
     """Get platform/OS information.
 
     Returns:
@@ -80,7 +80,7 @@ def get_platform_info() -> dict[str, str]:
     }
 
 
-def _get_pip_package_version(package_name: str) -> str | None:
+def _get_pip_package_version(package_name: str) -> Optional[str]:
     """Get package version via pip show.
 
     Args:
@@ -106,8 +106,8 @@ def _get_pip_package_version(package_name: str) -> str | None:
 
 
 def _get_package_version(
-    module_name: str, package_name: str | None = None
-) -> str | None:
+    module_name: str, package_name: Optional[str] = None
+) -> Optional[str]:
     """Get package version, trying __version__ first, then pip show.
 
     Args:
@@ -135,13 +135,13 @@ def _get_package_version(
     return _get_pip_package_version(package_name)
 
 
-def get_dependency_versions() -> dict[str, str | None]:
+def get_dependency_versions() -> Dict[str, Optional[str]]:
     """Get versions of key dependencies.
 
     Returns:
         Dict mapping package names to version strings (or None if not installed).
     """
-    deps: dict[str, str | None] = {}
+    deps: Dict[str, Optional[str]] = {}
 
     deps["pydantic"] = _get_package_version("pydantic")
     deps["pydantic_core"] = _get_package_version("pydantic_core", "pydantic-core")
@@ -152,7 +152,7 @@ def get_dependency_versions() -> dict[str, str | None]:
     return deps
 
 
-def get_version_info() -> dict[str, Any]:
+def get_version_info() -> Dict[str, Any]:
     """Get comprehensive version and system information.
 
     Returns:
@@ -173,7 +173,7 @@ def get_version_info() -> dict[str, Any]:
     }
 
 
-def format_version_info(info: dict[str, Any] | None = None) -> str:
+def format_version_info(info: Optional[Dict[str, Any]] = None) -> str:
     """Format version info as a human-readable string with aligned colons.
 
     Args:

--- a/registry/container.py
+++ b/registry/container.py
@@ -18,7 +18,7 @@ Unknown data keys (not in builder signature) go to meta._unused_data.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Dict, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
@@ -50,8 +50,8 @@ class BuildCfg(BaseModel):
     # ``data`` is required (no default) so that the envelope can be detected
     # unambiguously -- a plain dict like ``{"type": "x"}`` (e.g. a class with
     # a `type` constructor param) does not accidentally match the schema.
-    data: dict[str, Any]
-    meta: dict[str, Any] = Field(default_factory=dict)
+    data: Dict[str, Any]
+    meta: Dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def move_extra_to_meta(self) -> BuildCfg:
@@ -74,7 +74,7 @@ class BuildCfg(BaseModel):
                 )
         return self
 
-    def with_unused_data(self, unused: dict[str, Any]) -> BuildCfg:
+    def with_unused_data(self, unused: Dict[str, Any]) -> BuildCfg:
         """Return a copy with unused data merged into meta._unused_data."""
         if not unused:
             return self
@@ -101,9 +101,9 @@ def is_build_cfg(value: Any) -> bool:
 
 
 def normalize_cfg(
-    cfg: dict[str, Any] | BuildCfg,
+    cfg: Union[Dict[str, Any], BuildCfg],
     *,
-    context: dict[str, Any] | None = None,
+    context: Optional[Dict[str, Any]] = None,
 ) -> BuildCfg:
     """Normalize a raw dict or BuildCfg into a validated BuildCfg.
 

--- a/registry/engines.py
+++ b/registry/engines.py
@@ -17,7 +17,7 @@ import logging
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 
 import yaml as yaml_lib
 
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 __all__ = ["ConfigFileEngine"]
 
 
-class ConfigFileEngine(FunctionalRegistry[[Path], dict[str, Any]]):
+class ConfigFileEngine(FunctionalRegistry[[Path], Dict[str, Any]]):
     """Registry for config file loaders.
 
     Each registered function takes a filepath and returns a config dict.
@@ -43,49 +43,49 @@ class ConfigFileEngine(FunctionalRegistry[[Path], dict[str, Any]]):
 
 
 @ConfigFileEngine.register_artifact
-def json(filepath: Path) -> dict[str, Any]:
+def json(filepath: Path) -> Dict[str, Any]:
     """Load config from JSON file."""
     with open(filepath) as f:
         return json_lib.load(f)
 
 
 @ConfigFileEngine.register_artifact
-def yaml(filepath: Path) -> dict[str, Any]:
+def yaml(filepath: Path) -> Dict[str, Any]:
     """Load config from YAML file. Requires the ``yaml`` extra."""
     with open(filepath) as f:
         return yaml_lib.safe_load(f)
 
 
 @ConfigFileEngine.register_artifact
-def yml(filepath: Path) -> dict[str, Any]:
+def yml(filepath: Path) -> Dict[str, Any]:
     """Load config from YML file (alias for yaml)."""
     return yaml(filepath)
 
 
 @ConfigFileEngine.register_artifact
-def toml(filepath: Path) -> dict[str, Any]:
+def toml(filepath: Path) -> Dict[str, Any]:
     """Load config from TOML file."""
     with open(filepath, "rb") as f:
         return tomli.load(f)
 
 
 @ConfigFileEngine.register_artifact
-def xml(filepath: Path) -> dict[str, Any]:
+def xml(filepath: Path) -> Dict[str, Any]:
     """Load config from XML file.
 
     Converts XML to dict structure. Attributes become keys prefixed with '@'.
     Text content becomes '_text' key.
     """
 
-    def element_to_dict(elem: ET.Element) -> dict[str, Any]:
-        result: dict[str, Any] = {}
+    def element_to_dict(elem: ET.Element) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
 
         # Attributes with @ prefix
         for key, value in elem.attrib.items():
             result[f"@{key}"] = value
 
         # Children
-        children: dict[str, list] = {}
+        children: Dict[str, list] = {}
         for child in elem:
             child_data = element_to_dict(child)
             if child.tag in children:

--- a/registry/experimental/torch_compat.py
+++ b/registry/experimental/torch_compat.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import hashlib
 import threading
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 from torch import nn
@@ -95,7 +95,7 @@ def device_of(value: Any) -> Any:
     return value
 
 
-def hash_state_dict(sd: dict[str, torch.Tensor]) -> str:
+def hash_state_dict(sd: Dict[str, torch.Tensor]) -> str:
     """Stable sha256 prefix of a state_dict for provenance / cache keys."""
     h = hashlib.sha256()
     for k in sorted(sd):
@@ -119,7 +119,7 @@ class SameDeviceAs(ValidateMarker):
 
     ref: str
 
-    def validate(self, value: Any, kwargs: dict[str, Any], ctx: dict[str, Any]) -> None:
+    def validate(self, value: Any, kwargs: Dict[str, Any], ctx: Dict[str, Any]) -> None:
         target = kwargs.get(self.ref, ctx.get(self.ref))
         if target is None:
             raise ValueError(f"SameDeviceAs: {self.ref!r} not in kwargs or ctx")
@@ -135,7 +135,7 @@ class BoundTo(ValidateMarker):
 
     ref: str
 
-    def validate(self, value: Any, kwargs: dict[str, Any], ctx: dict[str, Any]) -> None:
+    def validate(self, value: Any, kwargs: Dict[str, Any], ctx: Dict[str, Any]) -> None:
         ref_obj = kwargs.get(self.ref, ctx.get(self.ref))
         if not isinstance(ref_obj, nn.Module):
             raise ValueError(f"BoundTo: {self.ref!r} is not an nn.Module")
@@ -162,7 +162,7 @@ class VerifyChecksum(ValidateMarker):
 
     expected: str
 
-    def validate(self, value: Any, kwargs: dict[str, Any], ctx: dict[str, Any]) -> None:
+    def validate(self, value: Any, kwargs: Dict[str, Any], ctx: Dict[str, Any]) -> None:
         actual = hash_state_dict(value.state_dict())
         if actual != self.expected:
             raise ValueError(
@@ -170,7 +170,7 @@ class VerifyChecksum(ValidateMarker):
             )
 
 
-def _shape_or_none(value: Any) -> tuple[int, ...] | None:
+def _shape_or_none(value: Any) -> Optional[Tuple[int, ...]]:
     """``value.shape[1:]`` for tensors / (tensor, ...) tuples; else None."""
     x = value[0] if isinstance(value, (tuple, list)) and value else value
     if isinstance(x, torch.Tensor):
@@ -178,7 +178,7 @@ def _shape_or_none(value: Any) -> tuple[int, ...] | None:
     return None
 
 
-def _meta_shape(obj: Any, key: str) -> tuple[int, ...] | None:
+def _meta_shape(obj: Any, key: str) -> Optional[Tuple[int, ...]]:
     """Look ``key`` up in ``obj.__meta__`` (if any). Returns a tuple or None."""
     meta = getattr(obj, "__meta__", None) or {}
     value = meta.get(key)
@@ -196,7 +196,7 @@ class MatchesInputShape(ValidateMarker):
 
     ref: str
 
-    def validate(self, value: Any, kwargs: dict[str, Any], ctx: dict[str, Any]) -> None:
+    def validate(self, value: Any, kwargs: Dict[str, Any], ctx: Dict[str, Any]) -> None:
         ref_obj = kwargs.get(self.ref, ctx.get(self.ref))
         if ref_obj is None:
             return
@@ -219,7 +219,7 @@ class MatchesOutputShape(ValidateMarker):
 
     ref: str
 
-    def validate(self, value: Any, kwargs: dict[str, Any], ctx: dict[str, Any]) -> None:
+    def validate(self, value: Any, kwargs: Dict[str, Any], ctx: Dict[str, Any]) -> None:
         ref_obj = kwargs.get(self.ref, ctx.get(self.ref))
         if ref_obj is None:
             return
@@ -244,7 +244,7 @@ class MatchesTargetShape(ValidateMarker):
 
     ref: str
 
-    def validate(self, value: Any, kwargs: dict[str, Any], ctx: dict[str, Any]) -> None:
+    def validate(self, value: Any, kwargs: Dict[str, Any], ctx: Dict[str, Any]) -> None:
         ref_obj = kwargs.get(self.ref, ctx.get(self.ref))
         if ref_obj is None:
             return
@@ -269,7 +269,7 @@ class InputShape(ComputeMarker):
 
     name: str
 
-    def compute(self, value: Any) -> tuple[int, ...] | None:
+    def compute(self, value: Any) -> Optional[Tuple[int, ...]]:
         return _shape_or_none(value)
 
 
@@ -284,7 +284,7 @@ class OutputShape(ComputeMarker):
 
     name: str
 
-    def compute(self, value: Any) -> tuple[int, ...] | None:
+    def compute(self, value: Any) -> Optional[Tuple[int, ...]]:
         return _shape_or_none(value)
 
 
@@ -294,7 +294,7 @@ class InputShapeMatches(ValidateMarker):
 
     ref: str
 
-    def validate(self, value: Any, kwargs: dict[str, Any], ctx: dict[str, Any]) -> None:
+    def validate(self, value: Any, kwargs: Dict[str, Any], ctx: Dict[str, Any]) -> None:
         x = value[0] if isinstance(value, (tuple, list)) else value
         if not isinstance(x, torch.Tensor):
             return
@@ -376,10 +376,10 @@ class TorchProfilerMeter(FactoryMeter):
     def __init__(self, top_n: int = 5, record_shapes: bool = False) -> None:
         self._top_n: int = top_n
         self._record_shapes: bool = record_shapes
-        self._stack: list[Any] = []
+        self._stack: List[Any] = []
 
     def on_build_start(
-        self, *, cfg: Any, ctx: dict[str, Any], meta: dict[str, Any]
+        self, *, cfg: Any, ctx: Dict[str, Any], meta: Dict[str, Any]
     ) -> None:
         activities = [ProfilerActivity.CPU]
         if torch.cuda.is_available():
@@ -389,7 +389,7 @@ class TorchProfilerMeter(FactoryMeter):
         self._stack.append(prof)
 
     def on_built(
-        self, *, target: Any, result: Any, meta: dict[str, Any], ctx: dict[str, Any]
+        self, *, target: Any, result: Any, meta: Dict[str, Any], ctx: Dict[str, Any]
     ) -> None:
         if not self._stack:
             return
@@ -411,7 +411,7 @@ class TorchProfilerMeter(FactoryMeter):
         ]
 
     def on_error(
-        self, *, cfg: Any, exc: BaseException, ctx: dict[str, Any], meta: dict[str, Any]
+        self, *, cfg: Any, exc: BaseException, ctx: Dict[str, Any], meta: Dict[str, Any]
     ) -> None:
         if not self._stack:
             return
@@ -444,7 +444,7 @@ class TensorBoardReporter(FactoryReporter):
         self._lock = threading.Lock()
 
     def on_built(
-        self, *, target: Any, result: Any, meta: dict[str, Any], ctx: dict[str, Any]
+        self, *, target: Any, result: Any, meta: Dict[str, Any], ctx: Dict[str, Any]
     ) -> None:
         target_name = getattr(target, "__name__", str(target))
         with self._lock:

--- a/registry/factory.py
+++ b/registry/factory.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from .container import BuildCfg, is_build_cfg, normalize_cfg
 from .fnc_registry import _ALL_FN_REGISTRIES, FunctionalRegistry
@@ -42,7 +42,7 @@ _REF_RE = re.compile(r"^\$([A-Za-z_][\w.]*)(\(\))?$")
 
 # External-source schemes. Each handler maps a stripped URL (after the
 # leading ``$``) to a Python value -- typically a parsed dict.
-_REF_SCHEMES: dict[str, Any] = {}
+_REF_SCHEMES: Dict[str, Any] = {}
 
 
 def register_ref_scheme(prefix: str, handler: Any) -> None:
@@ -86,7 +86,7 @@ register_ref_scheme("http", _resolve_http_ref)
 register_ref_scheme("https", _resolve_http_ref)
 
 
-def _resolve_ref(s: str, scope: dict[str, Any]) -> Any:
+def _resolve_ref(s: str, scope: Dict[str, Any]) -> Any:
     """Resolve a ``$ref`` string.
 
     Supports:
@@ -126,7 +126,7 @@ def _repo_matches(reg_repo: str, query: str) -> bool:
     return reg_repo == query or reg_repo.startswith(query + ".")
 
 
-def resolve(type_name: str, repo: str | None = None) -> tuple[type, Any]:
+def resolve(type_name: str, repo: Optional[str] = None) -> Tuple[type, Any]:
     """Find the registry that holds ``type_name``.
 
     Returns ``(registry_class, artifact)``. When ``repo`` is provided, the
@@ -147,7 +147,7 @@ def resolve(type_name: str, repo: str | None = None) -> tuple[type, Any]:
     if cached is not None:
         return cached
 
-    matches: list[tuple[type, Any]] = []
+    matches: List[Tuple[type, Any]] = []
     for repo_path, reg in {**_ALL_TYPE_REGISTRIES, **_ALL_FN_REGISTRIES}.items():
         if repo is not None and not _repo_matches(repo_path, repo):
             continue
@@ -176,11 +176,11 @@ def resolve(type_name: str, repo: str | None = None) -> tuple[type, Any]:
 
 
 def validate(
-    target: type | Callable[..., Any] | str,
+    target: Union[Union[type, Callable[..., Any]], str],
     data: Any,
     *,
     validator: str = "python",
-) -> dict[str, Any]:
+) -> Dict[str, Any]:
     """Run the medium decoder + Pydantic schema check, return validated kwargs.
 
     Sits between ``resolve`` (no work) and ``build`` (full pipeline). Useful
@@ -196,12 +196,14 @@ def validate(
 
 
 def build(
-    cfg_or_target: BuildCfg | dict[str, Any] | type | Callable[..., Any],
+    cfg_or_target: Union[
+        Union[Union[BuildCfg, Dict[str, Any]], type], Callable[..., Any]
+    ],
     data: Any = None,  # pyright: ignore[reportRedeclaration]
     *,
     validator: str = "pydantic",
-    ctx: dict[str, Any] | None = None,
-    repo: str | None = None,
+    ctx: Optional[Dict[str, Any]] = None,
+    repo: Optional[str] = None,
 ) -> Any:
     """Recursively construct from a normalized envelope OR explicit class+data.
 
@@ -243,10 +245,10 @@ def build(
     elif repo is not None and isinstance(cfg, dict):
         cfg = {**cfg, "repo": repo}
     # Preserve a reference to the original dict so meta can be written back.
-    raw_dict: dict[str, Any] | None = cfg if isinstance(cfg, dict) else None
+    raw_dict: Optional[Dict[str, Any]] = cfg if isinstance(cfg, dict) else None
     cfg = normalize_cfg(cfg)
     ctx = dict(ctx) if ctx else {}
-    meta: dict[str, Any] = dict(
+    meta: Dict[str, Any] = dict(
         cfg.meta
     )  # available to meters from the very first stage
 
@@ -263,7 +265,7 @@ def build(
         validator_fn = resolve_validator(validator)
 
         # [1] recurse + $ref; later siblings can reference earlier ones
-        data: dict[str, Any] = {}
+        data: Dict[str, Any] = {}
         for k, v in cfg.data.items():
             scope = {**ctx, **data}
             if is_build_cfg(v):
@@ -274,7 +276,7 @@ def build(
                 data[k] = v
 
         # [2] config-layer validation
-        kwargs: dict[str, Any] = validator_fn(target, data)
+        kwargs: Dict[str, Any] = validator_fn(target, data)
 
         # [3] runtime-layer pre-validation
         pre = getattr(registry, "pre_call", None)
@@ -347,7 +349,7 @@ class SerializerRegistry(FunctionalRegistry):
     """String-keyed registry of serializer engines for ``serialize()``."""
 
 
-def _envelope_for(instance: Any, *, repo: str | None = None) -> dict[str, Any]:
+def _envelope_for(instance: Any, *, repo: Optional[str] = None) -> Dict[str, Any]:
     """Build the ``{type, data, meta}`` envelope from a constructed instance.
 
     Reads constructor-arg attributes for ``data``; invokes the registry's
@@ -369,9 +371,9 @@ def _envelope_for(instance: Any, *, repo: str | None = None) -> dict[str, Any]:
         if n != "self" and hasattr(instance, n)
     }
 
-    meta: dict[str, Any] = {}
-    registry: type | None = None
-    candidates: list[type] = []
+    meta: Dict[str, Any] = {}
+    registry: Optional[type] = None
+    candidates: List[type] = []
     for repo_path, reg in _ALL_TYPE_REGISTRIES.items():
         if repo is not None and not _repo_matches(repo_path, repo):
             continue
@@ -396,7 +398,7 @@ def _envelope_for(instance: Any, *, repo: str | None = None) -> dict[str, Any]:
 
 
 @SerializerRegistry.register_artifact
-def python(instance: Any, *, repo: str | None = None) -> dict[str, Any]:
+def python(instance: Any, *, repo: Optional[str] = None) -> Dict[str, Any]:
     """Envelope-shaped dict: ``{type, data, meta}``.
 
     ``data`` mirrors the instance's constructor kwargs; ``meta`` collects
@@ -407,7 +409,7 @@ def python(instance: Any, *, repo: str | None = None) -> dict[str, Any]:
 
 
 @SerializerRegistry.register_artifact
-def yaml(instance: Any, *, repo: str | None = None) -> str:
+def yaml(instance: Any, *, repo: Optional[str] = None) -> str:
     """YAML string of the envelope produced by :func:`python`."""
     import yaml as _yaml
 
@@ -415,7 +417,7 @@ def yaml(instance: Any, *, repo: str | None = None) -> str:
 
 
 @SerializerRegistry.register_artifact
-def json(instance: Any, *, repo: str | None = None) -> str:
+def json(instance: Any, *, repo: Optional[str] = None) -> str:
     """JSON string of the envelope produced by :func:`python`."""
     import json as _json
 
@@ -425,11 +427,11 @@ def json(instance: Any, *, repo: str | None = None) -> str:
 def serialize(
     instance: Any,
     *,
-    ctx: (
-        dict[str, Any] | None
-    ) = None,  # noqa: ARG001 -- reserved for future nested serdes
+    ctx: Optional[
+        Dict[str, Any]
+    ] = None,  # noqa: ARG001 -- reserved for future nested serdes
     serializator: str = "python",
-    repo: str | None = None,
+    repo: Optional[str] = None,
 ) -> Any:
     """Serialize ``instance`` into a ``BuildCfg``-shaped envelope.
 

--- a/registry/fnc_registry.py
+++ b/registry/fnc_registry.py
@@ -6,12 +6,23 @@ import inspect
 import logging
 import sys
 from abc import ABC
-from collections.abc import Callable, Hashable, MutableMapping
+from collections.abc import Hashable, MutableMapping
 from types import ModuleType
+
+# ``Callable`` is subscripted at runtime (base class, instantiation), which
+# needs the typing alias on Python 3.8 (``collections.abc.Callable[...]`` is
+# PEP 585, 3.9+).
 from typing import (
     Any,
+    Callable,
     ClassVar,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
     TypeVar,
+    Union,
     cast,
     get_args,
     overload,
@@ -26,7 +37,7 @@ from .schema import cache_schema, drop_schema
 from .storage import ThreadSafeLocalStorage
 
 # Module-level lookup populated by __init_subclass__; consumed by registry.factory._resolve.
-_ALL_FN_REGISTRIES: dict[str, type] = {}
+_ALL_FN_REGISTRIES: Dict[str, type] = {}
 from .utils import (  # noqa: E402
     ConformanceError,
     ValidationError,
@@ -73,8 +84,8 @@ class FunctionalRegistry(MutableValidatorMixin[Hashable, Callable[P, R]], ABC):
     _repository: MutableMapping[Hashable, Callable[P, R]]
     _strict: ClassVar[bool] = False
     repo: ClassVar[str] = "default"
-    __orig_bases__: ClassVar[tuple[type, ...]]
-    __slots__: ClassVar[tuple[str, ...]] = ()
+    __orig_bases__: ClassVar[Tuple[type, ...]]
+    __slots__: ClassVar[Tuple[str, ...]] = ()
 
     @classmethod
     def _get_mapping(cls) -> MutableMapping[Hashable, Callable[P, R]]:
@@ -92,7 +103,7 @@ class FunctionalRegistry(MutableValidatorMixin[Hashable, Callable[P, R]], ABC):
     def __init_subclass__(
         cls,
         strict: bool = False,
-        repo: str | None = None,
+        repo: Optional[str] = None,
         **kwargs,
     ) -> None:
         """Initialize a FunctionalRegistry subclass.
@@ -145,7 +156,7 @@ class FunctionalRegistry(MutableValidatorMixin[Hashable, Callable[P, R]], ABC):
         cls,
         artifact: Callable[P, R],
         *,
-        params_model: type[BaseModel] | None = None,
+        params_model: Optional[Type[BaseModel]] = None,
     ) -> Callable[P, R]:
         """Register a function artifact with optional params_model."""
         ...
@@ -155,7 +166,7 @@ class FunctionalRegistry(MutableValidatorMixin[Hashable, Callable[P, R]], ABC):
     def register_artifact(
         cls,
         *,
-        params_model: type[BaseModel] | None = None,
+        params_model: Optional[Type[BaseModel]] = None,
     ) -> Any:
         """Decorator form: register a function with optional params_model."""
         ...
@@ -163,10 +174,10 @@ class FunctionalRegistry(MutableValidatorMixin[Hashable, Callable[P, R]], ABC):
     @classmethod
     def register_artifact(  # pyright: ignore[reportIncompatibleMethodOverride]
         cls,
-        artifact: Callable[P, R] | None = None,
+        artifact: Optional[Callable[P, R]] = None,
         *,
-        params_model: type[BaseModel] | None = None,
-    ) -> Callable[P, R] | Any:
+        params_model: Optional[Type[BaseModel]] = None,
+    ) -> Union[Callable[P, R], Any]:
         """Register a function artifact with optional explicit params_model.
 
         Can be used as a decorator or called directly.
@@ -254,7 +265,7 @@ class FunctionalRegistry(MutableValidatorMixin[Hashable, Callable[P, R]], ABC):
         assert isinstance(
             module, ModuleType
         ), f"Expected ModuleType, got {type(module)}"
-        members: list[Any] = get_module_members(module)
+        members: List[Any] = get_module_members(module)
         ok, fail = 0, 0
         for obj in members:
             if not (inspect.isfunction(obj) or inspect.isbuiltin(obj)):

--- a/registry/markers.py
+++ b/registry/markers.py
@@ -32,7 +32,7 @@ Usage::
 
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Dict, Protocol, runtime_checkable
 
 __all__ = ["ValidateMarker", "ComputeMarker", "Marker"]
 
@@ -49,8 +49,8 @@ class ValidateMarker(Protocol):
     def validate(
         self,
         value: Any,
-        kwargs: dict[str, Any],
-        ctx: dict[str, Any],
+        kwargs: Dict[str, Any],
+        ctx: Dict[str, Any],
     ) -> None: ...
 
 

--- a/registry/meters.py
+++ b/registry/meters.py
@@ -25,7 +25,7 @@ import resource
 import threading
 import time
 import tracemalloc
-from typing import Any
+from typing import Any, Dict, List, Optional, Tuple
 
 __all__ = [
     "FactoryMeter",
@@ -54,7 +54,7 @@ class FactoryMeter:
     name: str = "factory_meter"
 
     def on_build_start(
-        self, *, cfg: Any, ctx: dict[str, Any], meta: dict[str, Any]
+        self, *, cfg: Any, ctx: Dict[str, Any], meta: Dict[str, Any]
     ) -> None:
         """Pre-recursion / pre-validation. Good place to record baselines."""
 
@@ -62,9 +62,9 @@ class FactoryMeter:
         self,
         *,
         target: Any,
-        kwargs: dict[str, Any],
-        ctx: dict[str, Any],
-        meta: dict[str, Any],
+        kwargs: Dict[str, Any],
+        ctx: Dict[str, Any],
+        meta: Dict[str, Any],
     ) -> None:
         """After kwargs assembled + validated, before ``target(**kwargs)``."""
 
@@ -73,8 +73,8 @@ class FactoryMeter:
         *,
         target: Any,
         result: Any,
-        meta: dict[str, Any],
-        ctx: dict[str, Any],
+        meta: Dict[str, Any],
+        ctx: Dict[str, Any],
     ) -> None:
         """After invocation + post hooks. Compute deltas and write to ``meta``."""
 
@@ -83,8 +83,8 @@ class FactoryMeter:
         *,
         cfg: Any,
         exc: BaseException,
-        ctx: dict[str, Any],
-        meta: dict[str, Any],
+        ctx: Dict[str, Any],
+        meta: Dict[str, Any],
     ) -> None:
         """Build failed. Clean up any baseline state."""
 
@@ -93,7 +93,7 @@ class FactoryMeter:
 # Module-level meter registry
 # ---------------------------------------------------------------------------
 
-_METERS: dict[str, FactoryMeter] = {}
+_METERS: Dict[str, FactoryMeter] = {}
 _LOCK = threading.Lock()
 
 
@@ -104,13 +104,13 @@ def attach_meter(meter: FactoryMeter) -> FactoryMeter:
     return meter
 
 
-def detach_meter(name: str) -> FactoryMeter | None:
+def detach_meter(name: str) -> Optional[FactoryMeter]:
     """Remove and return the meter registered under ``name``."""
     with _LOCK:
         return _METERS.pop(name, None)
 
 
-def meters() -> dict[str, FactoryMeter]:
+def meters() -> Dict[str, FactoryMeter]:
     """Snapshot of currently attached meters."""
     with _LOCK:
         return dict(_METERS)
@@ -137,13 +137,13 @@ class _StackedMeter(FactoryMeter):
     """Base for meters that take a baseline at on_build_start and emit a delta at on_built."""
 
     def __init__(self) -> None:
-        self._stack: list[tuple[Any, ...]] = []
+        self._stack: List[Tuple[Any, ...]] = []
 
-    def _sample(self) -> tuple[Any, ...]:
+    def _sample(self) -> Tuple[Any, ...]:
         raise NotImplementedError
 
     def _write(
-        self, meta: dict[str, Any], before: tuple[Any, ...], after: tuple[Any, ...]
+        self, meta: Dict[str, Any], before: Tuple[Any, ...], after: Tuple[Any, ...]
     ) -> None:
         raise NotImplementedError
 
@@ -170,7 +170,7 @@ class LifetimeMeter(_StackedMeter):
 
     name: str = "lifetime"
 
-    def _sample(self) -> tuple[float]:
+    def _sample(self) -> Tuple[float]:
         return (time.perf_counter(),)
 
     def _write(self, meta, before, after) -> None:
@@ -182,7 +182,7 @@ class CPUMeter(_StackedMeter):
 
     name: str = "cpu"
 
-    def _sample(self) -> tuple[float, float]:
+    def _sample(self) -> Tuple[float, float]:
         r = resource.getrusage(resource.RUSAGE_SELF)
         return (r.ru_utime, r.ru_stime)
 
@@ -196,7 +196,7 @@ class MemoryMeter(_StackedMeter):
 
     name: str = "memory"
 
-    def _sample(self) -> tuple[int]:
+    def _sample(self) -> Tuple[int]:
         return (resource.getrusage(resource.RUSAGE_SELF).ru_maxrss,)
 
     def _write(self, meta, before, after) -> None:
@@ -210,10 +210,10 @@ class IOMeter(_StackedMeter):
     name: str = "io"
 
     @staticmethod
-    def _read_proc_io() -> dict[str, int]:
+    def _read_proc_io() -> Dict[str, int]:
         try:
             with open("/proc/self/io") as f:
-                out: dict[str, int] = {}
+                out: Dict[str, int] = {}
                 for line in f:
                     k, _, v = line.partition(": ")
                     out[k.strip()] = int(v.strip())
@@ -221,7 +221,7 @@ class IOMeter(_StackedMeter):
         except OSError:
             return {}
 
-    def _sample(self) -> tuple[int, int, int, int]:
+    def _sample(self) -> Tuple[int, int, int, int]:
         s = self._read_proc_io()
         return (
             s.get("read_bytes", 0),
@@ -243,7 +243,7 @@ class NetworkMeter(_StackedMeter):
     name: str = "network"
 
     @staticmethod
-    def _read_proc_net_dev() -> tuple[int, int]:
+    def _read_proc_net_dev() -> Tuple[int, int]:
         rx_total = 0
         tx_total = 0
         try:
@@ -259,7 +259,7 @@ class NetworkMeter(_StackedMeter):
             pass
         return (rx_total, tx_total)
 
-    def _sample(self) -> tuple[int, int]:
+    def _sample(self) -> Tuple[int, int]:
         return self._read_proc_net_dev()
 
     def _write(self, meta, before, after) -> None:
@@ -277,7 +277,7 @@ class HeapMeter(_StackedMeter):
         if not tracemalloc.is_tracing():
             tracemalloc.start()
 
-    def _sample(self) -> tuple[int, int]:
+    def _sample(self) -> Tuple[int, int]:
         return tracemalloc.get_traced_memory()
 
     def _write(self, meta, before, after) -> None:

--- a/registry/mixin/accessor.py
+++ b/registry/mixin/accessor.py
@@ -23,7 +23,7 @@ Simple inheritance diagram (Doxygen dot):
 from __future__ import annotations
 
 from collections.abc import Hashable, Iterator, MutableMapping
-from typing import Generic, TypeVar
+from typing import Dict, Generic, TypeVar, Union
 
 from ..utils import RegistryError, get_type_name
 
@@ -107,7 +107,7 @@ class RegistryAccessorMixin(Generic[KeyType, ValType]):
     @classmethod
     def _assert_presence(
         cls, key: KeyType
-    ) -> dict[KeyType, ValType] | MutableMapping[KeyType, ValType]:
+    ) -> Union[Dict[KeyType, ValType], MutableMapping[KeyType, ValType]]:
         """Return mapping if `key` is present; otherwise raise `RegistryError`."""
         mapping = cls._get_mapping()
         if key not in mapping:

--- a/registry/mixin/mutator.py
+++ b/registry/mixin/mutator.py
@@ -22,7 +22,7 @@ Simple inheritance diagram (Doxygen dot):
 from __future__ import annotations
 
 from collections.abc import Hashable, Mapping, MutableMapping
-from typing import TypeVar
+from typing import Dict, TypeVar, Union
 
 from ..utils import RegistryError, get_type_name
 from .accessor import RegistryAccessorMixin
@@ -124,7 +124,7 @@ class RegistryMutatorMixin(RegistryAccessorMixin[KeyType, ValType]):
     @classmethod
     def _assert_absence(
         cls, key: KeyType
-    ) -> dict[KeyType, ValType] | MutableMapping[KeyType, ValType]:
+    ) -> Union[Dict[KeyType, ValType], MutableMapping[KeyType, ValType]]:
         """Return mapping if `key` is absent; otherwise raise `RegistryError`."""
         mapping = cls._get_mapping()
         if key in mapping:

--- a/registry/mixin/validator.py
+++ b/registry/mixin/validator.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import logging
 import time
 from threading import RLock
+from typing import Dict, List, Optional, Tuple, Union
 
 logger = logging.getLogger(__name__)
 from collections.abc import Hashable, Iterator  # noqa: E402
@@ -72,13 +73,13 @@ class ValidationCache:
         self.max_size: int = max_size
         self.ttl: float = ttl_seconds
         # (id, type_name, op) -> (result, ts, suggestions_tuple)
-        self._cache: dict[tuple[Hashable, str, str], tuple[bool, float, list[str]]] = {}
+        self._cache: Dict[Tuple[Hashable, str, str], Tuple[bool, float, List[str]]] = {}
         self._lock: RLock = RLock()
 
     def _now(self) -> float:
         return time.monotonic()
 
-    def get(self, obj: Any, operation: str) -> tuple[bool, list[str]] | None:
+    def get(self, obj: Any, operation: str) -> Optional[Tuple[bool, List[str]]]:
         """Return cached `(result, suggestions)` for `obj`/`operation`, or `None`."""
         key = (id(obj), get_type_name(type(obj)), operation)
         with self._lock:
@@ -94,7 +95,7 @@ class ValidationCache:
             return result, list(sugg_tuple)
 
     def set(
-        self, obj: Any, operation: str, result: bool, suggestions: list[str]
+        self, obj: Any, operation: str, result: bool, suggestions: List[str]
     ) -> None:
         """Insert or replace cache entry for `obj`/`operation` with a TTL."""
         key = (id(obj), get_type_name(type(obj)), operation)
@@ -120,7 +121,7 @@ def clear_validation_cache() -> int:
         return count
 
 
-def get_cache_stats() -> dict[str, Any]:
+def get_cache_stats() -> Dict[str, Any]:
     """Return simple stats for the module-level cache.
 
     Expired entries are counted against `time.time()`, not `time.monotonic()`.
@@ -143,7 +144,7 @@ def get_cache_stats() -> dict[str, Any]:
 
 
 def configure_validation_cache(
-    max_size: int | None = None, ttl_seconds: float | None = None
+    max_size: Optional[int] = None, ttl_seconds: Optional[float] = None
 ) -> None:
     """Mutate the module-level cache configuration.
 
@@ -169,7 +170,7 @@ def _is_hashable(value: Any) -> bool:
     return isinstance(value, Hashable)
 
 
-def _resolve_typevars(cls: type) -> tuple[Any, Any]:
+def _resolve_typevars(cls: type) -> Tuple[Any, Any]:
     if not hasattr(cls, "__orig_bases__"):
         raise TypeError(f"Expected a parametrized Generic subclass, got {cls!r}")
 
@@ -393,7 +394,7 @@ class MutableValidatorMixin(
 
     @classmethod
     def register_artifact(
-        cls, key: KeyType | ValType, item: ValType | None = None
+        cls, key: Union[KeyType, ValType], item: Optional[ValType] = None
     ) -> ValType:
         """Register an artifact with validation; supports explicit or inferred keys."""
         if item is None:
@@ -509,7 +510,7 @@ class MutableValidatorMixin(
     # -----------------------------------------------------------------------------
 
     @classmethod
-    def validate_registry_state(cls) -> dict[str, Any]:
+    def validate_registry_state(cls) -> Dict[str, Any]:
         """Validate every artifact and return a summary report."""
         total_artifacts = cls._len_mapping()
         validation_errors = []
@@ -549,20 +550,20 @@ class MutableValidatorMixin(
 
     @classmethod
     def configure_validation(
-        cls, cache_size: int | None = None, cache_ttl: float | None = None
+        cls, cache_size: Optional[int] = None, cache_ttl: Optional[float] = None
     ) -> None:
         """Adjust shared validation cache parameters for this process."""
         configure_validation_cache(cache_size, cache_ttl)
 
     @classmethod
-    def get_validation_stats(cls) -> dict[str, Any]:
+    def get_validation_stats(cls) -> Dict[str, Any]:
         """Return shared validation cache statistics."""
         return get_cache_stats()
 
     @classmethod
     def batch_validate(
-        cls, items: dict[KeyType, ValType]
-    ) -> dict[KeyType, bool | ValidationError]:
+        cls, items: Dict[KeyType, ValType]
+    ) -> Dict[KeyType, Union[bool, ValidationError]]:
         """Validate multiple items without registering them.
 
         Returns:
@@ -593,16 +594,16 @@ class MutableValidatorMixin(
 
     @classmethod
     def safe_register_batch(
-        cls, items: dict[KeyType, ValType], skip_invalid: bool = True
-    ) -> dict[str, Any]:
+        cls, items: Dict[KeyType, ValType], skip_invalid: bool = True
+    ) -> Dict[str, Any]:
         """Register multiple items with per-item error capture.
 
         Returns:
             Dict with keys: successful, failed, total, errors.
         """
-        successful: list[KeyType] = []
-        failed: list[KeyType] = []
-        errors: list[dict[str, Any]] = []
+        successful: List[KeyType] = []
+        failed: List[KeyType] = []
+        errors: List[Dict[str, Any]] = []
         for key, item in items.items():
             try:
                 cls.register_artifact(key, item)

--- a/registry/reporters.py
+++ b/registry/reporters.py
@@ -21,7 +21,7 @@ import json
 import syslog
 import threading
 import time
-from typing import Any
+from typing import Any, Dict, List, Optional, Tuple
 
 __all__ = [
     "FactoryReporter",
@@ -41,16 +41,16 @@ class FactoryReporter:
     name: str = "factory_reporter"
 
     def on_build_start(
-        self, *, cfg: Any, ctx: dict[str, Any], meta: dict[str, Any]
+        self, *, cfg: Any, ctx: Dict[str, Any], meta: Dict[str, Any]
     ) -> None: ...
 
     def on_validated(
         self,
         *,
         target: Any,
-        kwargs: dict[str, Any],
-        ctx: dict[str, Any],
-        meta: dict[str, Any],
+        kwargs: Dict[str, Any],
+        ctx: Dict[str, Any],
+        meta: Dict[str, Any],
     ) -> None: ...
 
     def on_built(
@@ -58,8 +58,8 @@ class FactoryReporter:
         *,
         target: Any,
         result: Any,
-        meta: dict[str, Any],
-        ctx: dict[str, Any],
+        meta: Dict[str, Any],
+        ctx: Dict[str, Any],
     ) -> None: ...
 
     def on_error(
@@ -67,8 +67,8 @@ class FactoryReporter:
         *,
         cfg: Any,
         exc: BaseException,
-        ctx: dict[str, Any],
-        meta: dict[str, Any],
+        ctx: Dict[str, Any],
+        meta: Dict[str, Any],
     ) -> None: ...
 
 
@@ -76,7 +76,7 @@ class FactoryReporter:
 # Reporter registry
 # ---------------------------------------------------------------------------
 
-_REPORTERS: dict[str, FactoryReporter] = {}
+_REPORTERS: Dict[str, FactoryReporter] = {}
 _LOCK = threading.Lock()
 
 
@@ -87,13 +87,13 @@ def attach_reporter(reporter: FactoryReporter) -> FactoryReporter:
     return reporter
 
 
-def detach_reporter(name: str) -> FactoryReporter | None:
+def detach_reporter(name: str) -> Optional[FactoryReporter]:
     """Remove and return the reporter registered under ``name``."""
     with _LOCK:
         return _REPORTERS.pop(name, None)
 
 
-def reporters() -> dict[str, FactoryReporter]:
+def reporters() -> Dict[str, FactoryReporter]:
     """Snapshot of currently attached reporters."""
     with _LOCK:
         return dict(_REPORTERS)
@@ -188,7 +188,7 @@ class HTTPDashboardReporter(FactoryReporter):
     def __init__(
         self, port: int = 8765, max_events: int = 200, host: str = "127.0.0.1"
     ) -> None:
-        self._events: list[dict[str, Any]] = []
+        self._events: List[Dict[str, Any]] = []
         self._max_events: int = max_events
         self._lock: threading.Lock = threading.Lock()
         self._server: http.server.HTTPServer = self._start_server(host, port)
@@ -285,7 +285,7 @@ class OpenTelemetryReporter(FactoryReporter):
             description="Wall time per registry.build invocation",
         )
         self._span_prefix = span_name_prefix
-        self._stack: list[tuple[Any, float, str]] = []  # (span, start_perf, type)
+        self._stack: List[Tuple[Any, float, str]] = []  # (span, start_perf, type)
 
     def on_build_start(self, *, cfg, ctx, meta) -> None:
         t = _type_of(cfg) or "unknown"

--- a/registry/resolve_cache.py
+++ b/registry/resolve_cache.py
@@ -12,14 +12,14 @@ entries are dropped.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Dict, Optional, Tuple
 
 __all__ = ["RESOLVE_CACHE", "invalidate_resolve_cache"]
 
 
 # (type_name, repo) -> (registry_class, artifact). ``repo`` is None when
 # the resolve call did not narrow by repo.
-RESOLVE_CACHE: dict[tuple[str, str | None], tuple[type, Any]] = {}
+RESOLVE_CACHE: Dict[Tuple[str, Optional[str]], Tuple[type, Any]] = {}
 
 
 def invalidate_resolve_cache() -> None:

--- a/registry/schema.py
+++ b/registry/schema.py
@@ -30,6 +30,9 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple, Type, Union
 
+# ``typing.get_type_hints`` gained ``include_extras`` (needed to read
+# Annotated[...] markers) in 3.9; typing_extensions backports it to 3.8.
+import typing_extensions
 from pydantic import BaseModel, create_model
 
 from .type_guard import Buildable
@@ -68,7 +71,7 @@ def _resolved_hints(target: Union[type, Callable[..., Any]]) -> Dict[str, Any]:
     """
     obj = target.__init__ if isinstance(target, type) else target
     try:
-        return typing.get_type_hints(obj, include_extras=True)
+        return typing_extensions.get_type_hints(obj, include_extras=True)
     except Exception:
         # Best effort: use raw annotations from the signature.
         sig = inspect.signature(obj)

--- a/registry/schema.py
+++ b/registry/schema.py
@@ -28,7 +28,7 @@ import typing
 import weakref
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Dict, Optional, Tuple, Type, Union
 
 from pydantic import BaseModel, create_model
 
@@ -50,7 +50,7 @@ __all__ = [
 ]
 
 
-_JSON_NATIVE: tuple[type, ...] = (int, float, str, bool, type(None), list, dict, tuple)
+_JSON_NATIVE: Tuple[type, ...] = (int, float, str, bool, type(None), list, dict, tuple)
 
 
 def _unwrap_annotated(tp: Any) -> Any:
@@ -60,7 +60,7 @@ def _unwrap_annotated(tp: Any) -> Any:
     return tp
 
 
-def _resolved_hints(target: type | Callable[..., Any]) -> dict[str, Any]:
+def _resolved_hints(target: Union[type, Callable[..., Any]]) -> Dict[str, Any]:
     """Resolve annotations on ``target``, evaluating string forms.
 
     Falls back to ``inspect.signature(...).parameters[name].annotation`` if
@@ -111,11 +111,11 @@ def _config_type_for(tp: Any) -> Any:
     return Any
 
 
-def _signature_of(target: type | Callable[..., Any]) -> inspect.Signature:
+def _signature_of(target: Union[type, Callable[..., Any]]) -> inspect.Signature:
     return inspect.signature(target.__init__ if isinstance(target, type) else target)
 
 
-def derive_config_schema(target: type | Callable[..., Any]) -> type[BaseModel]:
+def derive_config_schema(target: Union[type, Callable[..., Any]]) -> Type[BaseModel]:
     """Build a Pydantic model from ``target``'s signature for input validation.
 
     No ``arbitrary_types_allowed``. Arbitrary classes are rewritten to
@@ -123,7 +123,7 @@ def derive_config_schema(target: type | Callable[..., Any]) -> type[BaseModel]:
     """
     sig = _signature_of(target)
     hints = _resolved_hints(target)
-    fields: dict[str, Any] = {}
+    fields: Dict[str, Any] = {}
     for name, p in sig.parameters.items():
         if name == "self" or p.kind in (
             inspect.Parameter.VAR_POSITIONAL,
@@ -141,8 +141,8 @@ def derive_config_schema(target: type | Callable[..., Any]) -> type[BaseModel]:
 
 
 def derive_meta_schema(
-    target: type | Callable[..., Any],
-) -> type[BaseModel] | None:
+    target: Union[type, Callable[..., Any]],
+) -> Optional[Type[BaseModel]]:
     """Walk ``Annotated[T, Marker(...)]`` metadata; collect compute markers.
 
     Returns a Pydantic model with one field per marker (name -> return type),
@@ -153,7 +153,7 @@ def derive_meta_schema(
     from pydantic import ConfigDict
 
     hints = _resolved_hints(target)
-    fields: dict[str, Any] = {}
+    fields: Dict[str, Any] = {}
     for hint in hints.values():
         if not hasattr(hint, "__metadata__"):
             continue
@@ -176,8 +176,8 @@ def derive_meta_schema(
 
 
 def resolve_data_schema(
-    registry: type, target: type | Callable[..., Any]
-) -> type[BaseModel]:
+    registry: type, target: Union[type, Callable[..., Any]]
+) -> Type[BaseModel]:
     """Explicit ``registry.data_schema`` wins; otherwise serve from cache."""
     explicit = getattr(registry, "data_schema", None)
     if explicit is not None:
@@ -186,8 +186,8 @@ def resolve_data_schema(
 
 
 def resolve_meta_schema(
-    registry: type, target: type | Callable[..., Any]
-) -> type[BaseModel] | None:
+    registry: type, target: Union[type, Callable[..., Any]]
+) -> Optional[Type[BaseModel]]:
     """Explicit ``registry.meta_schema`` wins; otherwise serve from cache."""
     explicit = getattr(registry, "meta_schema", None)
     if explicit is not None:
@@ -196,9 +196,9 @@ def resolve_meta_schema(
 
 
 def process_validate(
-    target: type | Callable[..., Any],
-    kwargs: dict[str, Any],
-    ctx: dict[str, Any],
+    target: Union[type, Callable[..., Any]],
+    kwargs: Dict[str, Any],
+    ctx: Dict[str, Any],
 ) -> None:
     """Run every ``Annotated[..., marker_with_validate].validate(value, kwargs, ctx)``."""
     hints = ensure_schema(target).hints
@@ -211,9 +211,9 @@ def process_validate(
 
 
 def process_compute(
-    target: type | Callable[..., Any],
-    kwargs: dict[str, Any],
-    meta: dict[str, Any],
+    target: Union[type, Callable[..., Any]],
+    kwargs: Dict[str, Any],
+    meta: Dict[str, Any],
 ) -> None:
     """Run every ``Annotated[..., marker_with_compute].compute(value)`` and write to meta."""
     hints = ensure_schema(target).hints
@@ -245,9 +245,9 @@ class ArtifactSchema:
       build and ``get_type_hints`` is itself expensive.
     """
 
-    config: type[BaseModel]
-    meta: type[BaseModel] | None
-    hints: dict[str, Any]
+    config: Type[BaseModel]
+    meta: Optional[Type[BaseModel]]
+    hints: Dict[str, Any]
 
 
 _SCHEMA_CACHE: weakref.WeakKeyDictionary[Any, ArtifactSchema] = (
@@ -257,9 +257,9 @@ _SCHEMA_LOCK = threading.Lock()
 
 
 def build_schema(
-    target: type | Callable[..., Any],
+    target: Union[type, Callable[..., Any]],
     *,
-    config_override: type[BaseModel] | None = None,
+    config_override: Optional[Type[BaseModel]] = None,
 ) -> ArtifactSchema:
     """Derive an :class:`ArtifactSchema` for ``target`` without caching.
 
@@ -276,9 +276,9 @@ def build_schema(
 
 
 def cache_schema(
-    target: type | Callable[..., Any],
+    target: Union[type, Callable[..., Any]],
     *,
-    config_override: type[BaseModel] | None = None,
+    config_override: Optional[Type[BaseModel]] = None,
 ) -> ArtifactSchema:
     """Build the schema for ``target`` and store it in the weak cache.
 
@@ -294,12 +294,12 @@ def cache_schema(
     return schema
 
 
-def get_schema(target: Any) -> ArtifactSchema | None:
+def get_schema(target: Any) -> Optional[ArtifactSchema]:
     """Return the cached :class:`ArtifactSchema` for ``target`` or ``None``."""
     return _SCHEMA_CACHE.get(target)
 
 
-def ensure_schema(target: type | Callable[..., Any]) -> ArtifactSchema:
+def ensure_schema(target: Union[type, Callable[..., Any]]) -> ArtifactSchema:
     """Return the cached schema, deriving + caching on the first miss.
 
     Double-checked under a lock so concurrent first-builds for the same

--- a/registry/storage.py
+++ b/registry/storage.py
@@ -7,11 +7,13 @@ from collections.abc import (
     ItemsView,
     Iterator,
     KeysView,
-    MutableMapping,
     ValuesView,
 )
 from threading import RLock
-from typing import Generic, TypeVar
+
+# ``MutableMapping`` is subscripted as a base class below, which requires the
+# typing alias on Python 3.8 (``collections.abc`` generics are PEP 585, 3.9+).
+from typing import Dict, Generic, MutableMapping, TypeVar
 
 __all__ = ["ThreadSafeLocalStorage"]
 
@@ -25,7 +27,7 @@ class ThreadSafeLocalStorage(
     """Thread-safe local storage with single-write multi-read semantics."""
 
     def __init__(self):
-        self._storage: dict[KeyType, ValType] = {}
+        self._storage: Dict[KeyType, ValType] = {}
         self._lock = RLock()
 
     def __getitem__(self, key: KeyType) -> ValType:

--- a/registry/typ_registry.py
+++ b/registry/typ_registry.py
@@ -11,8 +11,14 @@ from types import ModuleType
 from typing import (
     Any,
     ClassVar,
+    Dict,
     Generic,
+    List,
+    Optional,
+    Tuple,
+    Type,
     TypeVar,
+    Union,
     cast,
     overload,
 )
@@ -25,7 +31,7 @@ from .schema import cache_schema, drop_schema
 from .storage import ThreadSafeLocalStorage
 
 # Module-level lookup populated by __init_subclass__; consumed by registry.factory._resolve.
-_ALL_TYPE_REGISTRIES: dict[str, type] = {}
+_ALL_TYPE_REGISTRIES: Dict[str, type] = {}
 
 
 def _base_type_of(cls: type) -> Any:
@@ -100,8 +106,8 @@ def _validate_class_structure(subcls: type, /, exp_type: type) -> type:
             get_type_name(subcls),
             get_type_name(exp_type),
         )
-    missing: list[str] = []
-    sig_errs: list[str] = []
+    missing: List[str] = []
+    sig_errs: List[str] = []
     for name in dir(exp_type):
         if name.startswith("_"):
             continue
@@ -119,8 +125,8 @@ def _validate_class_structure(subcls: type, /, exp_type: type) -> type:
             except ConformanceError as e:
                 sig_errs.append(f"{name}: {e.message}")
     if missing or sig_errs:
-        parts: list[str] = []
-        hints: list[str] = []
+        parts: List[str] = []
+        hints: List[str] = []
         if missing:
             parts.append(f"Missing methods: {', '.join(missing)}")
             hints.extend([f"Add method: {m}(...) -> ..." for m in missing])
@@ -142,7 +148,7 @@ def _validate_class_structure(subcls: type, /, exp_type: type) -> type:
 
 
 class TypeRegistry(
-    MutableValidatorMixin[Hashable, type[Cls]],
+    MutableValidatorMixin[Hashable, Type[Cls]],
     ABC,
     Generic[Cls],
 ):
@@ -153,14 +159,14 @@ class TypeRegistry(
       - Strict mode for protocol/inheritance checking
     """
 
-    _repository: MutableMapping[Hashable, type[Cls]]
+    _repository: MutableMapping[Hashable, Type[Cls]]
     _strict: ClassVar[bool] = False
     _abstract: ClassVar[bool] = False
     repo: ClassVar[str] = "default"
-    __slots__: ClassVar[tuple[str, ...]] = ()
+    __slots__: ClassVar[Tuple[str, ...]] = ()
 
     @classmethod
-    def _get_mapping(cls) -> MutableMapping[Hashable, type[Cls]]:
+    def _get_mapping(cls) -> MutableMapping[Hashable, Type[Cls]]:
         return cls._repository
 
     @classmethod
@@ -168,7 +174,7 @@ class TypeRegistry(
         cls,
         strict: bool = False,
         abstract: bool = False,
-        repo: str | None = None,
+        repo: Optional[str] = None,
         **kwargs,
     ) -> None:
         """Initialize the TypeRegistry subclass.
@@ -185,7 +191,7 @@ class TypeRegistry(
         backing (e.g. a JSON-only RPC adapter on top of an external service).
         """
         super().__init_subclass__(**kwargs)
-        cls._repository = ThreadSafeLocalStorage[Hashable, type[Cls]]()
+        cls._repository = ThreadSafeLocalStorage[Hashable, Type[Cls]]()
         cls._strict = strict
         cls._abstract = abstract
         cls.repo = repo if repo is not None else cls.__name__
@@ -201,7 +207,7 @@ class TypeRegistry(
         )
 
     @classmethod
-    def _internalize_artifact(cls, value: Any) -> type[Cls]:
+    def _internalize_artifact(cls, value: Any) -> Type[Cls]:
         """Validate and internalize a class artifact."""
         v = _validate_class(value)
         if cls._abstract:
@@ -217,7 +223,7 @@ class TypeRegistry(
         return super()._internalize_artifact(v)
 
     @classmethod
-    def _identifier_of(cls, item: type[Cls]) -> Hashable:
+    def _identifier_of(cls, item: Type[Cls]) -> Hashable:
         """Return the identifier (class name) for an artifact."""
         return get_type_name(_validate_class(item))
 
@@ -229,10 +235,10 @@ class TypeRegistry(
     @classmethod
     def register_artifact(
         cls,
-        artifact: type[Cls],
+        artifact: Type[Cls],
         *,
-        params_model: type[BaseModel] | None = None,
-    ) -> type[Cls]:
+        params_model: Optional[Type[BaseModel]] = None,
+    ) -> Type[Cls]:
         """Register a class artifact with optional params_model."""
         ...
 
@@ -241,7 +247,7 @@ class TypeRegistry(
     def register_artifact(
         cls,
         *,
-        params_model: type[BaseModel] | None = None,
+        params_model: Optional[Type[BaseModel]] = None,
     ) -> Any:
         """Decorator form: register a class with optional params_model."""
         ...
@@ -249,10 +255,10 @@ class TypeRegistry(
     @classmethod
     def register_artifact(  # pyright: ignore[reportIncompatibleMethodOverride]
         cls,
-        artifact: type[Cls] | None = None,
+        artifact: Optional[Type[Cls]] = None,
         *,
-        params_model: type[BaseModel] | None = None,
-    ) -> type[Cls] | Any:
+        params_model: Optional[Type[BaseModel]] = None,
+    ) -> Union[Type[Cls], Any]:
         """Register a class artifact with optional explicit params_model.
 
         Can be used as a decorator or called directly.
@@ -277,10 +283,10 @@ class TypeRegistry(
                 def __init__(self, x: int): ...
         """
 
-        def _do_register(art: type[Cls]) -> type[Cls]:
+        def _do_register(art: Type[Cls]) -> Type[Cls]:
             # Use parent's register_artifact for the actual registration
             registered = cast(
-                type[Cls], super(TypeRegistry, cls).register_artifact(art)
+                Type[Cls], super(TypeRegistry, cls).register_artifact(art)
             )
             # Eagerly populate the per-target schema cache. Explicit
             # params_model wins over the auto-derived config schema.

--- a/registry/type_guard.py
+++ b/registry/type_guard.py
@@ -27,7 +27,7 @@ Usage:
 from __future__ import annotations
 
 import logging
-from typing import Any, Generic, TypeVar, get_args, get_origin
+from typing import Any, Dict, Generic, Type, TypeVar, get_args, get_origin
 
 from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
 from pydantic.json_schema import JsonSchemaValue
@@ -46,7 +46,7 @@ __all__ = [
 T = TypeVar("T")
 
 # Cache for parameterized types to avoid recreation
-_PARAMETERIZED_CACHE: dict[type, type] = {}
+_PARAMETERIZED_CACHE: Dict[type, type] = {}
 
 
 def _runtime_type(expected_type: type) -> type:
@@ -74,7 +74,7 @@ class BuildableValidator(Generic[T]):
     as a type annotation in Pydantic models.
     """
 
-    def __init__(self, expected_type: type[T]):
+    def __init__(self, expected_type: Type[T]):
         self.expected_type = expected_type
 
     def validate(self, value: Any) -> T:
@@ -219,7 +219,7 @@ class Buildable(Generic[T]):
 
     __slots__ = ()
 
-    def __class_getitem__(cls, item: type[T]) -> type:
+    def __class_getitem__(cls, item: Type[T]) -> type:
         """Support Buildable[SomeType] syntax."""
         # Check cache first
         if item in _PARAMETERIZED_CACHE:

--- a/registry/utils.py
+++ b/registry/utils.py
@@ -38,8 +38,13 @@ from inspect import (
 from types import ModuleType
 from typing import (
     Any,
+    Dict,
     Generic,
+    List,
+    Optional,
+    Tuple,
     TypeVar,
+    Union,
     get_args,
     get_origin,
 )
@@ -64,8 +69,8 @@ class ValidationError(Exception):
     def __init__(
         self,
         message: str,
-        suggestions: list[str] | None = None,
-        context: dict[str, Any] | None = None,
+        suggestions: Optional[List[str]] = None,
+        context: Optional[Dict[str, Any]] = None,
     ):
         self.message = message
         self.suggestions = suggestions or []
@@ -192,7 +197,7 @@ R = TypeVar("R")
 """Type variable for the result value."""
 
 
-def get_subclasses(cls: type) -> list[type]:
+def get_subclasses(cls: type) -> List[type]:
     """Get subclasses of a class."""
     if isclass(cls):
         return cls.__subclasses__()
@@ -213,7 +218,7 @@ def get_object_name(obj: Any) -> str:
 
 def get_module_members(
     module: ModuleType, ignore_all_keyword: bool = False
-) -> list[Any]:
+) -> List[Any]:
     """Get members of a module."""
     assert ismodule(module), f"{module} is not a module"
     if ignore_all_keyword or not hasattr(module, "__all__"):
@@ -340,8 +345,8 @@ def _validate_function_signature(
                 )
         return
 
-    errs: list[str] = []
-    hints: list[str] = []
+    errs: List[str] = []
+    hints: List[str] = []
 
     actual_params = list(actual_sig.parameters.values())
 
@@ -399,8 +404,8 @@ def _validate_function_signature(
 
 
 def get_callable_signature(
-    artifact: Callable[..., Any] | type,
-) -> tuple[str, Signature, list[Parameter]]:
+    artifact: Union[Callable[..., Any], type],
+) -> Tuple[str, Signature, List[Parameter]]:
     """Extract signature from a class or callable, removing 'self' for classes.
 
     Args:
@@ -446,7 +451,7 @@ def get_callable_signature(
         )
 
 
-def pydantic_to_dict(model: Any) -> dict[str, Any]:
+def pydantic_to_dict(model: Any) -> Dict[str, Any]:
     """Convert a Pydantic model to dict, compatible with v1 and v2.
 
     Args:
@@ -462,11 +467,11 @@ def pydantic_to_dict(model: Any) -> dict[str, Any]:
 
 def build_error_context(
     operation: str,
-    registry_cls: type | None = None,
-    key: Any | None = None,
-    artifact: Any | None = None,
+    registry_cls: Optional[type] = None,
+    key: Optional[Any] = None,
+    artifact: Optional[Any] = None,
     **extra: Any,
-) -> dict[str, Any]:
+) -> Dict[str, Any]:
     """Build a standardized error context dictionary.
 
     Args:
@@ -479,7 +484,7 @@ def build_error_context(
     Returns:
         Dictionary suitable for ValidationError context.
     """
-    context: dict[str, Any] = {"operation": operation}
+    context: Dict[str, Any] = {"operation": operation}
 
     if registry_cls is not None:
         context["registry_name"] = getattr(registry_cls, "__name__", "Unknown")
@@ -521,7 +526,7 @@ def is_hashable(value: Any) -> bool:
         return False
 
 
-def cleanup_dead_weakrefs(mapping: dict[Any, Any], key_is_weakref: bool = True) -> int:
+def cleanup_dead_weakrefs(mapping: Dict[Any, Any], key_is_weakref: bool = True) -> int:
     """Remove dead weakref entries from a mapping.
 
     Args:

--- a/registry/validators.py
+++ b/registry/validators.py
@@ -11,8 +11,10 @@ Pick by string name at ``build(cfg, validator=...)`` time.
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
+# ``Callable`` is subscripted at runtime in the ``Validator`` alias below,
+# which needs the typing alias on Python 3.8 (``collections.abc`` generics are
+# PEP 585, 3.9+).
+from typing import Any, Callable, Dict, Union
 
 from .fnc_registry import FunctionalRegistry
 from .schema import ensure_schema
@@ -20,7 +22,7 @@ from .schema import ensure_schema
 __all__ = ["ValidatorRegistry", "Validator"]
 
 
-Validator = Callable[[type | Callable[..., Any], dict[str, Any]], dict[str, Any]]
+Validator = Callable[[Union[type, Callable[..., Any]], Dict[str, Any]], Dict[str, Any]]
 
 
 class ValidatorRegistry(FunctionalRegistry):
@@ -28,7 +30,9 @@ class ValidatorRegistry(FunctionalRegistry):
 
 
 @ValidatorRegistry.register_artifact
-def pydantic(target: type | Callable[..., Any], data: dict[str, Any]) -> dict[str, Any]:
+def pydantic(
+    target: Union[type, Callable[..., Any]], data: Dict[str, Any]
+) -> Dict[str, Any]:
     """Validate ``data`` against the target's cached config schema.
 
     Reads from the per-target schema cache populated at registration time.
@@ -41,8 +45,8 @@ def pydantic(target: type | Callable[..., Any], data: dict[str, Any]) -> dict[st
 
 @ValidatorRegistry.register_artifact
 def jsonargparse(
-    target: type | Callable[..., Any], data: dict[str, Any]
-) -> dict[str, Any]:
+    target: Union[type, Callable[..., Any]], data: Dict[str, Any]
+) -> Dict[str, Any]:
     """Validate via jsonargparse's parser. Requires the ``jsonargparse`` extra."""
     import jsonargparse as ja  # pyright: ignore[reportMissingImports]
 
@@ -55,19 +59,21 @@ def jsonargparse(
 
 
 @ValidatorRegistry.register_artifact
-def noop(target: type | Callable[..., Any], data: dict[str, Any]) -> dict[str, Any]:
+def noop(
+    target: Union[type, Callable[..., Any]], data: Dict[str, Any]
+) -> Dict[str, Any]:
     """Passthrough -- no validation, no coercion."""
     return dict(data)
 
 
 @ValidatorRegistry.register_artifact
-def python(target: type | Callable[..., Any], data: Any) -> dict[str, Any]:
+def python(target: Union[type, Callable[..., Any]], data: Any) -> Dict[str, Any]:
     """Python-native dict input; validate against target's signature via Pydantic."""
     return pydantic(target, data if isinstance(data, dict) else dict(data))
 
 
 @ValidatorRegistry.register_artifact
-def yaml(target: type | Callable[..., Any], data: Any) -> dict[str, Any]:
+def yaml(target: Union[type, Callable[..., Any]], data: Any) -> Dict[str, Any]:
     """YAML string input; decode then python-validate."""
     import yaml as _yaml
 
@@ -76,7 +82,7 @@ def yaml(target: type | Callable[..., Any], data: Any) -> dict[str, Any]:
 
 
 @ValidatorRegistry.register_artifact
-def json(target: type | Callable[..., Any], data: Any) -> dict[str, Any]:
+def json(target: Union[type, Callable[..., Any]], data: Any) -> Dict[str, Any]:
     """JSON string input; decode then python-validate."""
     import json as _json
 
@@ -85,7 +91,7 @@ def json(target: type | Callable[..., Any], data: Any) -> dict[str, Any]:
 
 
 @ValidatorRegistry.register_artifact
-def argparse(target: type | Callable[..., Any], data: Any) -> dict[str, Any]:
+def argparse(target: Union[type, Callable[..., Any]], data: Any) -> Dict[str, Any]:
     """argparse.Namespace input; ``vars(ns)`` then python-validate."""
     decoded = (
         vars(data) if hasattr(data, "__dict__") and not isinstance(data, dict) else data


### PR DESCRIPTION
A prior `ruff --fix` reverted the py3.8 typing forms back to PEP 585/604 syntax, which pydantic evaluates at import time and Python 3.8 rejects. This restores the typing.* forms and moves `Callable`/`MutableMapping` to `typing` where they are subscripted at runtime (base classes, module-level aliases, instantiation). Ruff is pinned to py38 with the annotation-rewrite UP rules ignored so the forms are not reverted again.

Verified: imports and the full suite behave on 3.10 (155 pass); the package imports cleanly on a 3.8 interpreter.