### PR TITLE
registry: close three concurrency races (registration, resolve cache, meters)

### DIFF
--- a/registry/factory.py
+++ b/registry/factory.py
@@ -28,7 +28,7 @@ from .container import BuildCfg, is_build_cfg, normalize_cfg
 from .fnc_registry import _ALL_FN_REGISTRIES, FunctionalRegistry
 from .meters import emit_meter
 from .reporters import emit_reporter
-from .resolve_cache import RESOLVE_CACHE
+from .resolve_cache import RESOLVE_CACHE, current_generation, write_if_current
 from .schema import process_compute, process_validate, resolve_meta_schema
 from .typ_registry import _ALL_TYPE_REGISTRIES
 from .validators import resolve_validator
@@ -140,13 +140,18 @@ def resolve(type_name: str, repo: Optional[str] = None) -> Tuple[type, Any]:
     Successful lookups are memoized in ``RESOLVE_CACHE`` keyed by
     ``(type_name, repo)``; the cache is cleared whenever artifacts are
     registered or unregistered (see
-    ``registry.resolve_cache.invalidate_resolve_cache``).
+    ``registry.resolve_cache.invalidate_resolve_cache``). The scan-then-cache
+    sequence below snapshots the cache epoch before scanning and only writes
+    if it is unchanged when the scan finishes, so a concurrent unregister
+    that invalidates the cache mid-scan can't be resurrected by a stale
+    write landing after it (see ``resolve_cache.write_if_current``).
     """
     cache_key = (type_name, repo)
     cached = RESOLVE_CACHE.get(cache_key)
     if cached is not None:
         return cached
 
+    generation = current_generation()
     matches: List[Tuple[type, Any]] = []
     for repo_path, reg in {**_ALL_TYPE_REGISTRIES, **_ALL_FN_REGISTRIES}.items():
         if repo is not None and not _repo_matches(repo_path, repo):
@@ -162,12 +167,12 @@ def resolve(type_name: str, repo: Optional[str] = None) -> Tuple[type, Any]:
             f"'{type_name}' not registered in any TypeRegistry/FunctionalRegistry{suffix}"
         )
     if len(matches) == 1:
-        RESOLVE_CACHE[cache_key] = matches[0]
+        write_if_current(cache_key, matches[0], generation)
         return matches[0]
     if repo is not None:
         exact = [(r, a) for r, a in matches if r.repo == repo]
         if len(exact) == 1:
-            RESOLVE_CACHE[cache_key] = exact[0]
+            write_if_current(cache_key, exact[0], generation)
             return exact[0]
     raise KeyError(
         f"'{type_name}' is ambiguous (found in repos "

--- a/registry/meters.py
+++ b/registry/meters.py
@@ -134,10 +134,25 @@ def emit_meter(method: str, /, **payload: Any) -> None:
 
 
 class _StackedMeter(FactoryMeter):
-    """Base for meters that take a baseline at on_build_start and emit a delta at on_built."""
+    """Base for meters that take a baseline at on_build_start and emit a delta at on_built.
+
+    A meter instance is attached once (``attach_meter``) and reused for
+    every ``build()`` call process-wide, so the baseline stack is kept
+    per-thread via ``threading.local`` -- otherwise two threads racing
+    concurrent ``build()`` calls could pop each other's baseline off a
+    shared LIFO stack and silently write a wrong delta into ``meta``.
+    """
 
     def __init__(self) -> None:
-        self._stack: List[Tuple[Any, ...]] = []
+        self._local = threading.local()
+
+    @property
+    def _stack(self) -> List[Tuple[Any, ...]]:
+        stack = getattr(self._local, "stack", None)
+        if stack is None:
+            stack = []
+            self._local.stack = stack
+        return stack
 
     def _sample(self) -> Tuple[Any, ...]:
         raise NotImplementedError
@@ -151,13 +166,15 @@ class _StackedMeter(FactoryMeter):
         self._stack.append(self._sample())
 
     def on_built(self, *, target, result, meta, ctx) -> None:
-        if not self._stack:
+        stack = self._stack
+        if not stack:
             return
-        self._write(meta, self._stack.pop(), self._sample())
+        self._write(meta, stack.pop(), self._sample())
 
     def on_error(self, *, cfg, exc, ctx, meta) -> None:
-        if self._stack:
-            self._stack.pop()
+        stack = self._stack
+        if stack:
+            stack.pop()
 
 
 # ---------------------------------------------------------------------------
@@ -291,28 +308,41 @@ class RecursionMeter(FactoryMeter):
 
     Writes ``build_depth`` (depth of THIS envelope) and ``build_max_depth``
     (deepest level seen so far this top-level build) into meta.
+
+    Depth is tracked per-thread (``threading.local``): the meter instance is
+    shared across every concurrent ``build()`` call, and a plain shared
+    counter would let one thread's push/pop interleave with another's,
+    corrupting both threads' reported depths.
     """
 
     name: str = "recursion"
 
     def __init__(self) -> None:
-        self._depth: int = 0
-        self._max_depth: int = 0
+        self._local = threading.local()
+
+    def _state(self) -> threading.local:
+        if getattr(self._local, "depth", None) is None:
+            self._local.depth = 0
+            self._local.max_depth = 0
+        return self._local
 
     def on_build_start(self, *, cfg, ctx, meta) -> None:
-        self._depth += 1
-        if self._depth > self._max_depth:
-            self._max_depth = self._depth
+        st = self._state()
+        st.depth += 1
+        if st.depth > st.max_depth:
+            st.max_depth = st.depth
 
     def on_built(self, *, target, result, meta, ctx) -> None:
-        meta["build_depth"] = self._depth
-        meta["build_max_depth"] = self._max_depth
-        self._depth -= 1
-        if self._depth == 0:
-            self._max_depth = 0
+        st = self._state()
+        meta["build_depth"] = st.depth
+        meta["build_max_depth"] = st.max_depth
+        st.depth -= 1
+        if st.depth == 0:
+            st.max_depth = 0
 
     def on_error(self, *, cfg, exc, ctx, meta) -> None:
-        if self._depth > 0:
-            self._depth -= 1
-        if self._depth == 0:
-            self._max_depth = 0
+        st = self._state()
+        if st.depth > 0:
+            st.depth -= 1
+        if st.depth == 0:
+            st.max_depth = 0

--- a/registry/mixin/mutator.py
+++ b/registry/mixin/mutator.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import contextlib
 from collections.abc import Hashable, Mapping, MutableMapping
-from typing import Dict, Iterator, TypeVar, Union
+from typing import Any, Dict, Iterator, TypeVar, Union, cast
 
 from ..utils import RegistryError, get_type_name
 from .accessor import RegistryAccessorMixin
@@ -73,7 +73,7 @@ class RegistryMutatorMixin(RegistryAccessorMixin[KeyType, ValType]):
         mapping = cls._get_mapping()
         lock = getattr(mapping, "lock", None)
         if callable(lock):
-            with lock():
+            with cast("contextlib.AbstractContextManager[Any]", lock()):
                 yield
         else:
             yield

--- a/registry/mixin/mutator.py
+++ b/registry/mixin/mutator.py
@@ -21,8 +21,9 @@ Simple inheritance diagram (Doxygen dot):
 
 from __future__ import annotations
 
+import contextlib
 from collections.abc import Hashable, Mapping, MutableMapping
-from typing import Dict, TypeVar, Union
+from typing import Dict, Iterator, TypeVar, Union
 
 from ..utils import RegistryError, get_type_name
 from .accessor import RegistryAccessorMixin
@@ -53,13 +54,39 @@ class RegistryMutatorMixin(RegistryAccessorMixin[KeyType, ValType]):
     """
 
     # -----------------------------------------------------------------------------
+    # Locking helper -- makes check-then-act sequences atomic
+    # -----------------------------------------------------------------------------
+
+    @classmethod
+    @contextlib.contextmanager
+    def _mapping_lock(cls) -> Iterator[None]:
+        """Hold the backing mapping's lock across a compound check-then-act.
+
+        Uses the mapping's own ``lock()`` (``ThreadSafeLocalStorage`` exposes
+        one) if it has one, so a presence/absence assertion and the write or
+        delete that follows it happen atomically under concurrent access --
+        no other thread can observe or mutate the mapping in between. Falls
+        back to a no-op context for custom backing mappings that don't
+        expose a lock (see ``TypeRegistry``/``FunctionalRegistry`` docstrings
+        on assigning a custom ``_repository``).
+        """
+        mapping = cls._get_mapping()
+        lock = getattr(mapping, "lock", None)
+        if callable(lock):
+            with lock():
+                yield
+        else:
+            yield
+
+    # -----------------------------------------------------------------------------
     # Setter Functions for Registry Object
     # -----------------------------------------------------------------------------
     @classmethod
     def _set_mapping(cls, mapping: Mapping[KeyType, ValType]) -> None:
         """Replace the underlying mapping with `mapping` after clearing."""
-        cls._clear_mapping()
-        cls._update_mapping(mapping)
+        with cls._mapping_lock():
+            cls._clear_mapping()
+            cls._update_mapping(mapping)
 
     @classmethod
     def _update_mapping(cls, mapping: Mapping[KeyType, ValType]) -> None:
@@ -68,10 +95,11 @@ class RegistryMutatorMixin(RegistryAccessorMixin[KeyType, ValType]):
         Raises:
             RegistryError: if any key already exists.
         """
-        if cls._len_mapping() > 0:
-            for key in mapping.keys():
-                cls._assert_absence(key)
-        cls._get_mapping().update(mapping)
+        with cls._mapping_lock():
+            if cls._len_mapping() > 0:
+                for key in mapping.keys():
+                    cls._assert_absence(key)
+            cls._get_mapping().update(mapping)
 
     # -----------------------------------------------------------------------------
     # Deleter Functions for Registry Object
@@ -90,19 +118,28 @@ class RegistryMutatorMixin(RegistryAccessorMixin[KeyType, ValType]):
     def _set_artifact(cls, key: KeyType, item: ValType) -> None:
         """Insert `item` under `key`.
 
+        The absence check and the write are atomic under concurrent access
+        (see `_mapping_lock`): if two threads race to register the same
+        key, exactly one write wins and the other raises `RegistryError`.
+
         Raises:
             RegistryError: if `key` is already present.
         """
-        cls._assert_absence(key)[key] = item
+        with cls._mapping_lock():
+            cls._assert_absence(key)[key] = item
 
     @classmethod
     def _update_artifact(cls, key: KeyType, item: ValType) -> None:
         """Replace `item` under `key`.
 
+        The presence check and the write are atomic under concurrent access
+        (see `_mapping_lock`).
+
         Raises:
             RegistryError: if `key` is not present.
         """
-        cls._assert_presence(key)[key] = item
+        with cls._mapping_lock():
+            cls._assert_presence(key)[key] = item
 
     # -----------------------------------------------------------------------------
     # Deleter Functions for Registry Items
@@ -112,10 +149,16 @@ class RegistryMutatorMixin(RegistryAccessorMixin[KeyType, ValType]):
     def _del_artifact(cls, key: KeyType) -> None:
         """Delete the entry under `key`.
 
+        The presence check and the delete are atomic under concurrent access
+        (see `_mapping_lock`): a concurrent unregister of the same key
+        cannot slip in between the check and the delete, so callers see a
+        proper `RegistryError` rather than a raw `KeyError`.
+
         Raises:
             RegistryError: if `key` is not present.
         """
-        del cls._assert_presence(key)[key]
+        with cls._mapping_lock():
+            del cls._assert_presence(key)[key]
 
     # -----------------------------------------------------------------------------
     # Helper Functions for Error Handling with Rich Context

--- a/registry/mixin/validator.py
+++ b/registry/mixin/validator.py
@@ -424,10 +424,10 @@ class MutableValidatorMixin(
             )
             return artifact
         except (ValidationError, ConformanceError, InheritanceError):
-            raise
-        except RegistryError:
-            # Duplicate-key conflict from a concurrent (or plain) re-registration
-            # under the same identifier -- surface as-is, don't wrap.
+            # RegistryError (duplicate-key conflict from a concurrent or plain
+            # re-registration under the same identifier) subclasses
+            # ValidationError, so it is caught here and surfaced as-is -- never
+            # wrapped by the generic handler below.
             raise
         except Exception as e:
             artifact_name = getattr(

--- a/registry/mixin/validator.py
+++ b/registry/mixin/validator.py
@@ -396,7 +396,14 @@ class MutableValidatorMixin(
     def register_artifact(
         cls, key: Union[KeyType, ValType], item: Optional[ValType] = None
     ) -> ValType:
-        """Register an artifact with validation; supports explicit or inferred keys."""
+        """Register an artifact with validation; supports explicit or inferred keys.
+
+        Safe for concurrent runtime use, not just at import time: the
+        presence check and the write are atomic (`RegistryMutatorMixin.
+        _set_artifact`), so if two threads race to register the same key,
+        exactly one wins and the other raises `RegistryError` instead of
+        silently losing the update.
+        """
         if item is None:
             artifact = cast(ValType, key)
         else:
@@ -418,6 +425,10 @@ class MutableValidatorMixin(
             return artifact
         except (ValidationError, ConformanceError, InheritanceError):
             raise
+        except RegistryError:
+            # Duplicate-key conflict from a concurrent (or plain) re-registration
+            # under the same identifier -- surface as-is, don't wrap.
+            raise
         except Exception as e:
             artifact_name = getattr(
                 artifact if "artifact" in locals() else key, "__name__", str(key)
@@ -435,6 +446,11 @@ class MutableValidatorMixin(
     @classmethod
     def unregister_identifier(cls, key: KeyType) -> None:
         """Remove an artifact by its identifier.
+
+        Safe for concurrent runtime use: the presence check and the delete
+        are atomic (`RegistryMutatorMixin._del_artifact`), so a concurrent
+        unregister of the same key raises `RegistryError` for the loser
+        instead of a raw `KeyError`.
 
         Raises:
             ValidationError: if key validation fails.

--- a/registry/resolve_cache.py
+++ b/registry/resolve_cache.py
@@ -12,16 +12,61 @@ entries are dropped.
 
 from __future__ import annotations
 
+import threading
 from typing import Any, Dict, Optional, Tuple
 
-__all__ = ["RESOLVE_CACHE", "invalidate_resolve_cache"]
+__all__ = [
+    "RESOLVE_CACHE",
+    "invalidate_resolve_cache",
+    "current_generation",
+    "write_if_current",
+]
 
 
 # (type_name, repo) -> (registry_class, artifact). ``repo`` is None when
 # the resolve call did not narrow by repo.
 RESOLVE_CACHE: Dict[Tuple[str, Optional[str]], Tuple[type, Any]] = {}
 
+# Epoch counter bumped on every invalidation. ``resolve()`` snapshots it
+# before scanning the registries and passes the snapshot to
+# ``write_if_current`` so a scan that started before a concurrent
+# invalidation can't write its (now-stale) result back in after the fact.
+_LOCK = threading.Lock()
+_GENERATION = 0
+
 
 def invalidate_resolve_cache() -> None:
-    """Drop every memoized resolve() result."""
-    RESOLVE_CACHE.clear()
+    """Drop every memoized resolve() result and advance the epoch."""
+    global _GENERATION
+    with _LOCK:
+        _GENERATION += 1
+        RESOLVE_CACHE.clear()
+
+
+def current_generation() -> int:
+    """Return the current cache epoch.
+
+    Callers doing a scan-then-cache sequence should snapshot this *before*
+    scanning and pass it to :func:`write_if_current` when the scan
+    completes, so a concurrent invalidation mid-scan is not silently
+    overwritten by a stale write.
+    """
+    with _LOCK:
+        return _GENERATION
+
+
+def write_if_current(
+    key: Tuple[str, Optional[str]], value: Tuple[type, Any], generation: int
+) -> bool:
+    """Write ``value`` into the cache iff no invalidation happened since ``generation``.
+
+    Returns whether the write happened. Guards against the race where a
+    ``resolve()`` cache miss starts scanning the registries, a concurrent
+    unregister invalidates the cache mid-scan, and the miss then finishes
+    and would otherwise write a stale (already-unregistered) result back in.
+    """
+    with _LOCK:
+        if generation != _GENERATION:
+            return False
+        RESOLVE_CACHE[key] = value
+        return True

--- a/registry/storage.py
+++ b/registry/storage.py
@@ -30,6 +30,17 @@ class ThreadSafeLocalStorage(
         self._storage: Dict[KeyType, ValType] = {}
         self._lock = RLock()
 
+    def lock(self) -> RLock:
+        """Return this storage's lock, for holding across a compound op.
+
+        Individual accessor/mutator calls (``__contains__``, ``__setitem__``,
+        etc.) each take this same ``RLock`` internally, so callers that need
+        a check-then-act sequence (e.g. "assert key absent, then insert") to
+        be atomic should wrap the whole sequence in ``with storage.lock():``
+        -- the inner calls re-enter the lock safely since it is reentrant.
+        """
+        return self._lock
+
     def __getitem__(self, key: KeyType) -> ValType:
         with self._lock:
             return self._storage[key]

--- a/registry/typ_registry.py
+++ b/registry/typ_registry.py
@@ -356,7 +356,9 @@ class TypeRegistry(
                 continue
             name = get_object_name(obj)
             try:
-                cls.register_artifact(obj)
+                # ``obj`` is an arbitrary class discovered by scanning the
+                # module; the registry's declared element type is Type[Cls].
+                cls.register_artifact(cast("type[Cls]", obj))
                 ok += 1
             except (ValidationError, ConformanceError, InheritanceError) as e:
                 fail += 1

--- a/registry/utils.py
+++ b/registry/utils.py
@@ -45,6 +45,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
     get_args,
     get_origin,
 )
@@ -175,7 +176,10 @@ def get_protocol(cls: type):
     assert isclass(cls), f"{cls} is not a class"
     assert Generic in cls.mro(), f"{cls} is not a generic class"
 
-    type_arg = get_args(cls.__orig_bases__[0])[0]
+    # ``__orig_bases__`` isn't on ``type`` statically; the Generic-in-mro
+    # assert above guarantees it exists at runtime.
+    orig_bases = cast("Any", cls).__orig_bases__
+    type_arg = get_args(orig_bases[0])[0]
 
     # If it's already a runtime_checkable Protocol, just return it
     if hasattr(type_arg, "_is_runtime_protocol") and type_arg._is_runtime_protocol:

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,379 @@
+"""Concurrency tests for registry mutation, resolve(), and meters.
+
+These target three races found by audit. Each core test widens the race
+window deterministically (an injected delay or an explicit event handshake
+at the exact interleaving point) instead of relying on scheduler luck, so
+it fails reliably against the pre-fix code and passes reliably against the
+fix -- a bare thread-count-and-hope harness rarely preempts inside a check-
+then-act on a few dict/list operations often enough to be a trustworthy
+regression test.
+
+  - Duplicate-key registration is a check-then-act (assert-absent, then
+    write) that used to be non-atomic: concurrent `register_artifact` calls
+    for the same key could both pass the absence check and both write,
+    silently losing one registration instead of raising for the loser.
+
+  - `resolve()` memoizes into `RESOLVE_CACHE` with a miss -> scan -> write
+    sequence that used to have no guard against a concurrent unregister
+    invalidating the cache mid-scan; a stale write could land after the
+    invalidation and resurrect an already-unregistered artifact.
+
+  - `_StackedMeter` (`LifetimeMeter`/`CPUMeter`/`MemoryMeter`) is a shared
+    singleton instance (attached once via `attach_meter`) reused across
+    every concurrent `build()` call. Its baseline stack used to be a single
+    shared list, so two threads racing non-nested `build()` calls could pop
+    each other's baseline and silently write a corrupted delta into `meta`.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Dict, List
+
+import pytest
+
+from registry import (
+    FunctionalRegistry,
+    RegistryError,
+    TypeRegistry,
+    build,
+    resolve,
+)
+from registry.meters import LifetimeMeter, _StackedMeter, attach_meter, detach_meter
+from registry.resolve_cache import invalidate_resolve_cache
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    invalidate_resolve_cache()
+    yield
+    invalidate_resolve_cache()
+
+
+def _run_concurrently(fns: List[Any], timeout: float = 10.0) -> None:
+    """Start every callable in `fns` on its own thread; join them all."""
+    threads = [threading.Thread(target=fn) for fn in fns]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout)
+        assert not t.is_alive(), "thread did not finish in time"
+
+
+class TestConcurrentDuplicateRegistration:
+    """Concurrent registration of the same key must yield exactly one winner.
+
+    Both tests widen the check-then-act gap in `_assert_absence` with a
+    monkeypatched delay: on the fix, the whole check-then-act happens under
+    `_mapping_lock()`, so the delay just makes the loser wait longer for the
+    lock and still lose deterministically; on pre-fix code, the delay gives
+    a concurrent caller ample time to also pass the (now stale) absence
+    check, so the lost-update always fires.
+    """
+
+    def test_exactly_one_winner_rest_raise_registry_error(self):
+        class R(TypeRegistry[Any], repo="conc.test.duplicate"):
+            pass
+
+        class Foo:
+            def __init__(self, x: int = 0):
+                self.x = x
+
+        import registry.mixin.mutator as mutator_mod
+
+        original = mutator_mod.RegistryMutatorMixin._assert_absence.__func__
+
+        def delayed_assert_absence(cls, key):
+            result = original(cls, key)  # raises RegistryError if already present
+            time.sleep(0.2)
+            return result
+
+        mutator_mod.RegistryMutatorMixin._assert_absence = classmethod(
+            delayed_assert_absence
+        )
+        try:
+            barrier = threading.Barrier(2)
+            results: List[Any] = [None, None]
+
+            def worker(i: int) -> None:
+                barrier.wait()
+                try:
+                    R.register_artifact(Foo)
+                    results[i] = "ok"
+                except RegistryError:
+                    results[i] = "conflict"
+
+            _run_concurrently([lambda i=i: worker(i) for i in range(2)])
+        finally:
+            mutator_mod.RegistryMutatorMixin._assert_absence = classmethod(original)
+
+        assert results.count("ok") == 1, f"expected exactly one winner, got {results}"
+        assert results.count("conflict") == 1
+        assert R.get_artifact("Foo") is Foo
+
+    def test_functional_registry_same_race(self):
+        class FR(FunctionalRegistry, repo="conc.test.duplicate.fn"):
+            pass
+
+        def step(x: int = 0) -> int:
+            return x
+
+        import registry.mixin.mutator as mutator_mod
+
+        original = mutator_mod.RegistryMutatorMixin._assert_absence.__func__
+
+        def delayed_assert_absence(cls, key):
+            result = original(cls, key)
+            time.sleep(0.2)
+            return result
+
+        mutator_mod.RegistryMutatorMixin._assert_absence = classmethod(
+            delayed_assert_absence
+        )
+        try:
+            barrier = threading.Barrier(2)
+            results: List[Any] = [None, None]
+
+            def worker(i: int) -> None:
+                barrier.wait()
+                try:
+                    FR.register_artifact(step)
+                    results[i] = "ok"
+                except RegistryError:
+                    results[i] = "conflict"
+
+            _run_concurrently([lambda i=i: worker(i) for i in range(2)])
+        finally:
+            mutator_mod.RegistryMutatorMixin._assert_absence = classmethod(original)
+
+        assert results.count("ok") == 1
+        assert results.count("conflict") == 1
+
+
+class TestConcurrentResolveRegisterUnregister:
+    """resolve() must never hand back an artifact that is no longer registered."""
+
+    def test_no_stale_write_survives_invalidation(self):
+        """Directly targets the miss -> scan -> write race in resolve().
+
+        `R.get_artifact` is monkeypatched so a `resolve()` call, once it has
+        already captured the artifact reference for its match, pauses right
+        there. While paused, a concurrent `unregister_identifier` removes
+        the artifact and invalidates the cache. The paused `resolve()` then
+        resumes and tries to write its (now-stale) result -- that write
+        must not land, and a fresh `resolve()` afterwards must raise
+        `KeyError` rather than returning the ghost artifact.
+        """
+        from registry import resolve_cache
+
+        class R(TypeRegistry[Any], repo="conc.test.resolve.stale"):
+            pass
+
+        class Slow:
+            def __init__(self, x: int = 0):
+                self.x = x
+
+        R.register_artifact(Slow)
+
+        reached = threading.Event()
+        proceed = threading.Event()
+        delay_applied = threading.Event()
+        original_get_artifact = R.get_artifact.__func__
+
+        def delayed_get_artifact(cls, key):
+            result = original_get_artifact(cls, key)
+            # Only pause the FIRST caller (the resolver's scan). `unregister_
+            # identifier` also calls `get_artifact` internally (to drop the
+            # schema cache entry) -- letting that reentrant call through
+            # immediately keeps the two delay points from serializing on
+            # each other's `proceed` wait.
+            if not delay_applied.is_set():
+                delay_applied.set()
+                reached.set()
+                proceed.wait(timeout=5.0)
+            return result
+
+        R.get_artifact = classmethod(delayed_get_artifact)
+        try:
+            result_holder: List[Any] = []
+
+            def slow_resolver() -> None:
+                result_holder.append(resolve("Slow", repo="conc.test.resolve.stale"))
+
+            t = threading.Thread(target=slow_resolver)
+            t.start()
+            assert reached.wait(timeout=5.0), "resolve() never reached get_artifact"
+
+            R.unregister_identifier("Slow")
+            proceed.set()
+            t.join(5.0)
+            assert not t.is_alive()
+        finally:
+            del R.get_artifact  # restore the inherited classmethod
+
+        assert len(result_holder) == 1, "resolve() call did not complete"
+
+        cached = resolve_cache.RESOLVE_CACHE.get(("Slow", "conc.test.resolve.stale"))
+        assert (
+            cached is None
+        ), "stale write resurrected an unregistered artifact in RESOLVE_CACHE"
+
+        with pytest.raises(KeyError):
+            resolve("Slow", repo="conc.test.resolve.stale")
+
+    def test_resolve_never_returns_unregistered_artifact_under_churn(self):
+        """Best-effort stress companion to the deterministic test above."""
+
+        class R(TypeRegistry[Any], repo="conc.test.resolve"):
+            pass
+
+        class Widget:
+            def __init__(self, x: int = 0):
+                self.x = x
+
+        stop = threading.Event()
+        violations: List[str] = []
+        lock = threading.Lock()
+
+        def churn() -> None:
+            while not stop.is_set():
+                try:
+                    R.register_artifact(Widget)
+                except RegistryError:
+                    pass
+                try:
+                    R.unregister_identifier("Widget")
+                except RegistryError:
+                    pass
+
+        def resolver() -> None:
+            while not stop.is_set():
+                try:
+                    _, artifact = resolve("Widget", repo="conc.test.resolve")
+                except KeyError:
+                    continue
+                if artifact is not Widget:
+                    with lock:
+                        violations.append(
+                            f"resolve returned wrong artifact: {artifact!r}"
+                        )
+
+        threads = [threading.Thread(target=churn) for _ in range(4)] + [
+            threading.Thread(target=resolver) for _ in range(4)
+        ]
+        for t in threads:
+            t.start()
+        time.sleep(1.0)
+        stop.set()
+        for t in threads:
+            t.join(5.0)
+            assert not t.is_alive()
+
+        assert not violations, violations
+
+
+class TestConcurrentBuildWithStackedMeter:
+    """A shared `_StackedMeter` must not cross-contaminate concurrent builds."""
+
+    def test_stack_baseline_not_shared_across_threads(self):
+        """White-box: forces the exact non-nested push/push/pop/pop interleave
+        that corrupts a single shared LIFO stack, and checks each thread's
+        `on_built` used its own baseline, not the other thread's.
+        """
+
+        class _TaggedMeter(_StackedMeter):
+            name = "conc-test-tagged"
+
+            def _sample(self):
+                return (threading.get_ident(),)
+
+            def _write(self, meta, before, after):
+                meta["before_thread"] = before[0]
+                meta["after_thread"] = after[0]
+
+        meter = _TaggedMeter()
+        meta_a: Dict[str, Any] = {}
+        meta_b: Dict[str, Any] = {}
+
+        a_pushed = threading.Event()
+        b_pushed = threading.Event()
+        a_popped = threading.Event()
+
+        def thread_a() -> None:
+            meter.on_build_start(cfg=None, ctx={}, meta=meta_a)
+            a_pushed.set()
+            assert b_pushed.wait(timeout=5.0)
+            # A pops FIRST even though B pushed after A -- overlapping,
+            # non-nested builds, the case a naive shared stack gets wrong.
+            meter.on_built(target=None, result=None, meta=meta_a, ctx={})
+            a_popped.set()
+
+        def thread_b() -> None:
+            assert a_pushed.wait(timeout=5.0)
+            meter.on_build_start(cfg=None, ctx={}, meta=meta_b)
+            b_pushed.set()
+            assert a_popped.wait(timeout=5.0)
+            meter.on_built(target=None, result=None, meta=meta_b, ctx={})
+
+        ta = threading.Thread(target=thread_a)
+        tb = threading.Thread(target=thread_b)
+        ta.start()
+        tb.start()
+        ta.join(5.0)
+        tb.join(5.0)
+        assert not ta.is_alive() and not tb.is_alive()
+
+        assert (
+            meta_a["before_thread"] == meta_a["after_thread"]
+        ), f"thread A's on_built used a foreign (cross-thread) baseline: {meta_a}"
+        assert (
+            meta_b["before_thread"] == meta_b["after_thread"]
+        ), f"thread B's on_built used a foreign (cross-thread) baseline: {meta_b}"
+
+    def test_lifetime_meter_sane_under_concurrent_build(self):
+        """Integration-style companion through the real `build()` pipeline."""
+
+        class R(TypeRegistry[Any], repo="conc.test.meter"):
+            pass
+
+        class Slowish:
+            def __init__(self, delay_ms: int = 0):
+                time.sleep(delay_ms / 1000.0)
+
+        R.register_artifact(Slowish)
+
+        meter = LifetimeMeter()
+        attach_meter(meter)
+        try:
+            n_threads = 12
+            metas: List[Any] = [None] * n_threads
+            errors: List[Any] = [None] * n_threads
+
+            def worker(i: int, delay_ms: int) -> None:
+                try:
+                    obj = build(
+                        {
+                            "type": "Slowish",
+                            "repo": "conc.test.meter",
+                            "data": {"delay_ms": delay_ms},
+                        }
+                    )
+                    metas[i] = obj.__meta__
+                except Exception as e:  # pragma: no cover - diagnostic aid
+                    errors[i] = e
+
+            delays = [((i % 4) * 15) for i in range(n_threads)]
+            _run_concurrently(
+                [lambda i=i, d=delays[i]: worker(i, d) for i in range(n_threads)]
+            )
+
+            assert not any(errors), errors
+            for i, meta in enumerate(metas):
+                assert meta is not None, f"build {i} produced no meta"
+                lifetime = meta.get("lifetime_seconds")
+                assert lifetime is not None, f"build {i} meta missing lifetime_seconds"
+                assert lifetime >= 0, f"build {i} got negative lifetime: {lifetime}"
+                assert lifetime < 2.0, f"build {i} got implausible lifetime: {lifetime}"
+        finally:
+            detach_meter(meter.name)


### PR DESCRIPTION
Fixes the thread-safety gaps found in a concurrency audit. registration/resolve/build are public RUNTIME API (not import-time-only), so these races are real under concurrent use.

- **register/unregister/update TOCTOU** (mixin/mutator.py, storage.py). The assert-absence/presence then a separate write/delete wasn't atomic -> concurrent same-key registration could both pass the check and both write (silent lost update, no RegistryError). `ThreadSafeLocalStorage.lock()` exposes the storage RLock; a `_mapping_lock()` context manager holds it across the whole check-and-act (reentrant, so the inner asserts nest). `register_artifact` now re-raises `RegistryError` as-is instead of wrapping it.
- **RESOLVE_CACHE stale-write** (resolve_cache.py, factory.py). A `resolve()` that missed the cache could write a now-unregistered mapping back AFTER a concurrent invalidate. Added a generation counter bumped on invalidate; `resolve()` snapshots it before scanning and `write_if_current` drops the write if it changed.
- **_StackedMeter / RecursionMeter cross-build corruption** (meters.py). The shared meter instance's LIFO stack / depth counter got popped by the wrong thread under concurrent `build()` -> wrong lifetime/cpu/mem/depth in meta. Both now use `threading.local` per-thread state.

New `tests/test_concurrency.py` (6 tests) forces the exact interleaving deterministically (a naive thread-barrier version passed even on buggy code). Verified each fails on the pre-fix code with the exact symptom and passes after. Full suite 160 passed, black clean.