### PR TITLE
Fail loud on a malformed $ref, and add the $$ escape (0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to `registry-pattern` are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] -- 2026-08-14
+
+### Added
+- `$$` escape in the `$ref` grammar. A value starting with `$$` yields the
+  literal string with one leading `$` removed and is never resolved, so
+  `"$$HOME/data"` builds the kwarg `"$HOME/data"` and `"$$"` builds `"$"`.
+  It is checked before the scheme and regex logic, so escaping cannot be
+  overridden by a name that happens to be in scope. This is the only way to
+  pass a `$`-leading literal through the factory.
+
+### Changed
+- **Breaking:** `$ref` strings matching no accepted form now raise
+  `ValueError` instead of being passed through as literal kwargs.
+  `"$model.parameters(x)"`, `"$1abc"`, `"$a-b"` and `"$"` previously became
+  silent string kwargs; they are grammar errors and now fail at the cause.
+  The message quotes the offending string and lists the accepted forms.
+- **Breaking:** `$scheme://...` naming a scheme nobody registered now raises
+  `ValueError` listing the registered schemes. It previously fell through the
+  scheme lookup, missed the regex, and leaked out as a literal string.
+- An unresolvable *name* in a well-formed ref still raises `KeyError`. The
+  split is deliberate: `ValueError` marks a string that can never resolve in
+  any scope (an authoring error), `KeyError` marks a well-formed ref whose
+  target is absent from this particular scope (a lookup miss).
+
+### Notes
+- `_REF_RE` is unchanged, so a ref with an empty dotted segment (`"$h."`,
+  `"$h..x"`) is still accepted by the grammar and fails at the attribute
+  lookup with `AttributeError`. It is never passed through as a literal.
+
 ## [0.5.0] -- 2026-05-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "registry-pattern"
-version = "0.5.0"
+version = "0.5.1"
 description = "A flexible registry pattern with DI container, Pydantic validation, and recursive config building"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/registry/_version.py
+++ b/registry/_version.py
@@ -34,7 +34,7 @@ from typing import Any, Dict, Optional
 # Version components
 VERSION_MAJOR = 0
 VERSION_MINOR = 5
-VERSION_PATCH = 0
+VERSION_PATCH = 1
 VERSION_SUFFIX = ""  # e.g., "alpha", "beta", "rc1"
 
 __version__ = f"{VERSION_MAJOR}.{VERSION_MINOR}.{VERSION_PATCH}{'-' + VERSION_SUFFIX if VERSION_SUFFIX else ''}"

--- a/registry/factory.py
+++ b/registry/factory.py
@@ -35,10 +35,17 @@ from .validators import resolve_validator
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["build", "resolve", "validate", "serialize"]
+__all__ = ["build", "resolve", "validate", "serialize", "parse_ref"]
 
 
 _REF_RE = re.compile(r"^\$([A-Za-z_][\w.]*)(\(\))?$")
+
+# Quoted back to the author in every $ref grammar error.
+_REF_FORMS = (
+    "$name / $name.attr / $name.attr.method() (local scope lookup), "
+    "$scheme://... (registered scheme), "
+    "$$literal (escape -- yields the string with one leading '$' removed)"
+)
 
 # External-source schemes. Each handler maps a stripped URL (after the
 # leading ``$``) to a Python value -- typically a parsed dict.
@@ -86,33 +93,96 @@ register_ref_scheme("http", _resolve_http_ref)
 register_ref_scheme("https", _resolve_http_ref)
 
 
-def _resolve_ref(s: str, scope: Dict[str, Any]) -> Any:
-    """Resolve a ``$ref`` string.
+def parse_ref(s: str) -> Tuple[str, Any]:
+    """Classify a ``$``-string by grammar alone -- no scope, no I/O.
 
-    Supports:
-      - ``$name``, ``$name.attr``, ``$name.method()`` -- local lookup against
-        ``scope`` (siblings + ctx).
-      - ``$file:///path/to/cfg.yaml`` -- file load via ``ConfigFileEngine``.
-      - ``$http(s)://host/path`` -- HTTP GET + JSON decode.
+    This is the ONE definition of the ``$ref`` grammar. :func:`_resolve_ref`
+    is this parse plus a dispatch, and a static config checker (which has no
+    build-time scope, and must not fetch a ``$https://`` URL just to find out
+    whether the string is well formed) calls it directly.
 
-    Extend via :func:`register_ref_scheme`.
+    Returns ``(kind, payload)``:
+
+      - ``("escape", literal)`` -- ``$$x``; ``literal`` is ``s`` with one
+        leading ``$`` removed.
+      - ``("scheme", (scheme, url))`` -- ``$scheme://...`` for a REGISTERED
+        scheme; ``url`` is ``s`` without the leading ``$``, i.e. what the
+        handler is called with.
+      - ``("local", (parts, call))`` -- a scope lookup; ``parts`` is the
+        dotted path split on ``.`` and ``call`` is truthy when the ref ends
+        in ``()``.
+
+    Raises ``ValueError`` when the string is not a well-formed reference at
+    all (``"$1abc"``, ``"$a-b"``, ``"$model.parameters(x)"``, ``"$"``), or
+    when it names an unregistered scheme. Both are authoring errors: the
+    string can never resolve, in any scope. Name resolution is NOT decided
+    here -- it needs a scope, and stays with :func:`_resolve_ref`.
     """
+    # Escape first: ``$$...`` is a literal and bypasses every rule below.
+    if s.startswith("$$"):
+        return ("escape", s[1:])
+
     # External scheme: ``$scheme://...``
     if s.startswith("$"):
         bare = s[1:]
         scheme_sep = bare.find("://")
         if scheme_sep > 0:
             scheme = bare[:scheme_sep]
-            handler = _REF_SCHEMES.get(scheme)
-            if handler is not None:
-                return handler(bare)
+            if scheme not in _REF_SCHEMES:
+                raise ValueError(
+                    f"$ref {s!r}: unknown scheme '{scheme}' "
+                    f"(registered: {sorted(_REF_SCHEMES)}). "
+                    f"Accepted forms: {_REF_FORMS}"
+                )
+            return ("scheme", (scheme, bare))
 
     # Local scope lookup
     m = _REF_RE.match(s)
     if not m:
-        return s
+        raise ValueError(
+            f"$ref {s!r}: malformed reference. Accepted forms: {_REF_FORMS}"
+        )
     path, call = m.group(1), m.group(2)
-    parts = path.split(".")
+    return ("local", (path.split("."), call))
+
+
+def _resolve_ref(s: str, scope: Dict[str, Any]) -> Any:
+    """Resolve a ``$ref`` string.
+
+    Supports:
+      - ``$$literal`` -- ESCAPE. Yields the literal string with ONE leading
+        ``$`` removed and is never resolved, so ``"$$HOME/data"`` builds the
+        kwarg ``"$HOME/data"`` and ``"$$"`` builds ``"$"``. This is the only
+        way to pass a ``$``-leading literal through the factory.
+      - ``$name``, ``$name.attr``, ``$name.method()`` -- local lookup against
+        ``scope`` (siblings + ctx).
+      - ``$file:///path/to/cfg.yaml`` -- file load via ``ConfigFileEngine``.
+      - ``$http(s)://host/path`` -- HTTP GET + JSON decode.
+
+    Extend via :func:`register_ref_scheme`.
+
+    Failure modes -- a ``$``-string is never passed through as a literal:
+
+      - ``ValueError`` when the string is not a well-formed reference at all
+        (``"$1abc"``, ``"$a-b"``, ``"$model.parameters(x)"``, ``"$"``), or
+        when it is ``$scheme://...`` for a scheme nobody registered. Both are
+        authoring errors: the string can never resolve, in any scope, so the
+        config is wrong rather than merely unlucky.
+      - ``KeyError`` when the reference is well formed but the name it starts
+        from is absent from ``scope``. That depends on where the ref is used,
+        so it stays a lookup miss.
+
+    The grammar itself lives in :func:`parse_ref`; this is that parse plus
+    the dispatch that needs a scope (or the network).
+    """
+    kind, payload = parse_ref(s)
+    if kind == "escape":
+        return payload
+    if kind == "scheme":
+        scheme, url = payload
+        return _REF_SCHEMES[scheme](url)
+
+    parts, call = payload
     if parts[0] not in scope:
         raise KeyError(f"$ref {s!r}: '{parts[0]}' not in scope (have: {sorted(scope)})")
     obj: Any = scope[parts[0]]

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -322,7 +322,10 @@ def test_parse_ref_classifies_every_accepted_form() -> None:
     assert parse_ref("$$HOME/data") == ("escape", "$HOME/data")
     assert parse_ref("$file:///cfg.yaml") == ("scheme", ("file", "file:///cfg.yaml"))
     assert parse_ref("$model") == ("local", (["model"], None))
-    assert parse_ref("$model.parameters()") == ("local", (["model", "parameters"], "()"))
+    assert parse_ref("$model.parameters()") == (
+        "local",
+        (["model", "parameters"], "()"),
+    )
 
 
 def test_parse_ref_rejects_the_same_strings_resolve_rejects() -> None:
@@ -343,7 +346,10 @@ def test_parse_ref_does_not_call_the_scheme_handler() -> None:
     calls = []
     register_ref_scheme("tmpparse", lambda url: calls.append(url))
     try:
-        assert parse_ref("$tmpparse://a/b") == ("scheme", ("tmpparse", "tmpparse://a/b"))
+        assert parse_ref("$tmpparse://a/b") == (
+            "scheme",
+            ("tmpparse", "tmpparse://a/b"),
+        )
         assert calls == []
     finally:
         del _REF_SCHEMES["tmpparse"]

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 
 from registry import BuildCfg, FunctionalRegistry, TypeRegistry, build, resolve
+from registry.factory import _resolve_ref, parse_ref
 
 
 class _SampleModelRegistry(TypeRegistry[Any]):
@@ -180,3 +181,169 @@ def test_build_uses_noop_validator_when_requested() -> None:
     # pydantic strips unknowns (extra="ignore" default for create_model fields)
     obj = build({"type": "_Adder", "data": {"base": 9}})
     assert obj.base == 9
+
+
+# ---------------------------------------------------------------------------
+# $ref grammar: escape, fail-loud on malformed input
+# ---------------------------------------------------------------------------
+
+
+class _Holder:
+    """Target for method-call refs (``$holder.value()``)."""
+
+    def __init__(self, base: int = 0):
+        self.base = base
+
+    def value(self) -> int:
+        return self.base * 2
+
+
+def test_ref_escape_strips_one_dollar() -> None:
+    """``$$x`` is a literal ``$x`` -- the escape, never a lookup."""
+    assert _resolve_ref("$$HOME/data", {}) == "$HOME/data"
+
+
+def test_ref_escape_bare_double_dollar_yields_single() -> None:
+    assert _resolve_ref("$$", {}) == "$"
+
+
+def test_ref_escape_wins_over_a_resolvable_name() -> None:
+    """The escape is checked first: ``$$external`` stays literal even when
+    ``external`` IS in scope, so escaping is never silently overridden."""
+    sentinel = object()
+    assert _resolve_ref("$$external", {"external": sentinel}) == "$external"
+
+
+def test_ref_escape_end_to_end_through_build() -> None:
+    @_SampleFnRegistry.register_artifact
+    def takes_thing(thing: Any) -> Any:
+        return thing
+
+    out = build(
+        {"type": "takes_thing", "data": {"thing": "$$HOME/data"}},
+        ctx={"HOME": "/should/not/be/used"},
+    )
+    assert out == "$HOME/data"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "$model.parameters(x)",  # args in the call form
+        "$1abc",  # leading digit
+        "$a-b",  # hyphen is not a name char
+        "$",  # nothing to resolve
+        "$.leading.dot",
+        "$name()extra",
+    ],
+)
+def test_ref_malformed_raises_value_error(bad: str) -> None:
+    """A malformed $-string is a grammar error, not a literal kwarg."""
+    with pytest.raises(ValueError, match="malformed reference") as exc:
+        _resolve_ref(bad, {"model": _Holder(), "name": _Holder()})
+    msg = str(exc.value)
+    assert repr(bad) in msg  # quotes the offending string
+    assert "$$literal" in msg  # states the accepted forms
+    assert "$name.attr" in msg
+
+
+def test_ref_malformed_raises_through_build() -> None:
+    """The single call site propagates the grammar error instead of passing
+    the string through as a kwarg."""
+
+    @_SampleFnRegistry.register_artifact
+    def takes_thing(thing: Any) -> Any:
+        return thing
+
+    with pytest.raises(ValueError, match="malformed reference"):
+        build({"type": "takes_thing", "data": {"thing": "$a-b"}})
+
+
+def test_ref_unknown_scheme_raises_value_error() -> None:
+    """``$scheme://`` with no registered handler used to fall through the
+    scheme lookup, miss the regex, and leak out as a literal. Now it raises
+    and names the schemes that ARE registered."""
+    with pytest.raises(ValueError, match="unknown scheme") as exc:
+        _resolve_ref("$nosuchscheme://host/path", {})
+    msg = str(exc.value)
+    assert repr("$nosuchscheme://host/path") in msg
+    assert "nosuchscheme" in msg
+    assert "file" in msg  # lists the registered schemes
+    assert "$$literal" in msg
+
+
+def test_ref_registered_scheme_still_resolves() -> None:
+    """The registered-scheme path is untouched by the fail-loud change."""
+    from registry.factory import _REF_SCHEMES, register_ref_scheme
+
+    register_ref_scheme("tmpscheme", lambda url: {"got": url})
+    try:
+        assert _resolve_ref("$tmpscheme://a/b", {}) == {"got": "tmpscheme://a/b"}
+    finally:
+        del _REF_SCHEMES["tmpscheme"]
+
+
+def test_ref_wellformed_forms_unchanged() -> None:
+    """Regression guard: every accepted form resolves exactly as before."""
+    holder = _Holder(base=21)
+    scope = {"holder": holder, "plain": 7}
+    assert _resolve_ref("$plain", scope) == 7
+    assert _resolve_ref("$holder", scope) is holder
+    assert _resolve_ref("$holder.base", scope) == 21
+    assert _resolve_ref("$holder.value()", scope) == 42
+
+
+def test_ref_unknown_name_still_raises_key_error() -> None:
+    """A well-formed ref naming something absent from scope stays a KeyError
+    (a lookup miss), NOT the new ValueError (a grammar error)."""
+    with pytest.raises(KeyError, match="not in scope"):
+        _resolve_ref("$missing", {"present": 1})
+    with pytest.raises(KeyError, match="not in scope"):
+        _resolve_ref("$missing.attr", {"present": 1})
+
+
+def test_ref_empty_dotted_segment_fails_at_attribute_lookup() -> None:
+    """``_REF_RE`` accepts an empty dotted segment (``[\\w.]*`` allows a
+    trailing/doubled dot), so ``$h.`` is NOT caught by the grammar check.
+    It still fails loud -- at the attribute lookup -- and is never passed
+    through as a literal, which is what the fail-loud contract requires.
+    Documented so the export-side translator expects AttributeError here
+    rather than ValueError.
+    """
+    holder = _Holder(base=1)
+    with pytest.raises(AttributeError):
+        _resolve_ref("$holder.", {"holder": holder})
+    with pytest.raises(AttributeError):
+        _resolve_ref("$holder..base", {"holder": holder})
+
+
+def test_parse_ref_classifies_every_accepted_form() -> None:
+    """The grammar parse needs no scope: it classifies, it does not resolve."""
+    assert parse_ref("$$HOME/data") == ("escape", "$HOME/data")
+    assert parse_ref("$file:///cfg.yaml") == ("scheme", ("file", "file:///cfg.yaml"))
+    assert parse_ref("$model") == ("local", (["model"], None))
+    assert parse_ref("$model.parameters()") == ("local", (["model", "parameters"], "()"))
+
+
+def test_parse_ref_rejects_the_same_strings_resolve_rejects() -> None:
+    """One grammar, two callers: whatever ``_resolve_ref`` calls malformed,
+    ``parse_ref`` calls malformed -- with no scope and no I/O."""
+    for bad in ("$model.parameters(x)", "$1abc", "$a-b", "$", "$.leading.dot"):
+        with pytest.raises(ValueError, match="malformed reference"):
+            parse_ref(bad)
+    with pytest.raises(ValueError, match="unknown scheme"):
+        parse_ref("$nosuchscheme://host/path")
+
+
+def test_parse_ref_does_not_call_the_scheme_handler() -> None:
+    """A static checker must be able to grammar-check ``$https://...``
+    without fetching it, so the parse classifies and stops."""
+    from registry.factory import _REF_SCHEMES, register_ref_scheme
+
+    calls = []
+    register_ref_scheme("tmpparse", lambda url: calls.append(url))
+    try:
+        assert parse_ref("$tmpparse://a/b") == ("scheme", ("tmpparse", "tmpparse://a/b"))
+        assert calls == []
+    finally:
+        del _REF_SCHEMES["tmpparse"]


### PR DESCRIPTION
`_resolve_ref` had one silent path: a string starting with `$` that matched no
accepted form was returned unchanged as a literal kwarg. So a typo in a ref
reached the constructor as data instead of raising.

Measured before this change:

| value | result |
|---|---|
| `$nosuch.parameters()` | `KeyError` (correct) |
| `$model.parameters(x)` | `'$model.parameters(x)'` silently |
| `$model-foo`, `$1abc`, `$` | silently literal |
| `$unregistered://host` | silently literal |

A bad *name* failed loud; bad *syntax* did not. The two differ only in which
mistake the author made.

Malformed syntax now raises `ValueError` quoting the offending string and the
accepted forms, and an unregistered `$scheme://` raises naming the scheme and
listing the registered ones. `KeyError` stays reserved for a well-formed ref
whose first name is absent from this scope: a grammar error is wrong in every
scope, a name miss is wrong only in this one, and a caller can tell them apart.

`$$` is the escape for a value that really starts with a dollar. It is handled
before the scheme and regex logic, so an escape can never be overridden by a
name that happens to be in scope: `$$HOME/data` yields `$HOME/data`, `$$` yields
`$`, and neither is resolved. This is the only way to pass a `$`-leading literal
through the factory, which previously worked by accident via the silent path.

`parse_ref` is a new public entry point: the same grammar parse with no scope
and no scheme I/O, so a static checker can classify a `$`-string without
building anything. It exists because the alternative was a second copy of the
grammar in a downstream repo.

180 passed (was 177). The blast-radius survey found no `$`-leading literal in
any consumer: 32 torchfiles in the OptTrans corpus contain no `$` at all, and
torchestrator's only two refs are well formed.
